### PR TITLE
Docs sizing and custom scrollbar

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -6,7 +6,7 @@
 @import "syntax.css";
 
 .search-hit {
-  color: #fb923c
+  color: #fb923c;
 }
 
 /* Alerts and form errors used by phx.new */
@@ -96,4 +96,23 @@
   color: black;
   text-decoration: none;
   cursor: pointer;
+}
+
+/* Hide scrollbar for Chrome, Safari and Opera */
+.custom-scrollbar::-webkit-scrollbar {
+  width: 8px;
+  padding: 0px 4px 0px 4px;
+  margin-right: 12px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background-color: #888888;
+  border-radius: 12px;
+}
+
+/* Hide scrollbar for IE, Edge and Firefox */
+.custom-scrollbar {
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: 8px; /* Firefox */
+  scrollbar-color: #888888 transparent;
 }

--- a/lib/ash_hq_web/pages/docs.ex
+++ b/lib/ash_hq_web/pages/docs.ex
@@ -82,27 +82,29 @@ defmodule AshHqWeb.Pages.Docs do
         </div>
       </span>
       <div class="grow w-screen overflow-hidden flex flex-row h-full justify-between md:space-x-12 bg-white dark:bg-primary-black">
-        <DocSidebar
-          id="sidebar"
-          class="hidden xl:block pt-10 w-80 overflow-x-hidden border-r"
-          change_version={@change_version}
-          add_version={@add_version}
-          remove_version={@remove_version}
-          module={@module}
-          libraries={@libraries}
-          extension={@extension}
-          sidebar_state={@sidebar_state}
-          collapse_sidebar={@collapse_sidebar}
-          expand_sidebar={@expand_sidebar}
-          guide={@guide}
-          library={@library}
-          library_version={@library_version}
-          selected_versions={@selected_versions}
-          dsl={@dsl}
-        />
+        <div class="lg:border-r lg:pr-2 lg:pt-14">
+          <DocSidebar
+            id="sidebar"
+            class="hidden xl:block w-80 overflow-x-hidden custom-scrollbar"
+            change_version={@change_version}
+            add_version={@add_version}
+            remove_version={@remove_version}
+            module={@module}
+            libraries={@libraries}
+            extension={@extension}
+            sidebar_state={@sidebar_state}
+            collapse_sidebar={@collapse_sidebar}
+            expand_sidebar={@expand_sidebar}
+            guide={@guide}
+            library={@library}
+            library_version={@library_version}
+            selected_versions={@selected_versions}
+            dsl={@dsl}
+          />
+        </div>
         <div
           id="docs-window"
-          class="w-full prose prose-xl max-w-4xl dark:bg-primary-black dark:prose-invert overflow-y-auto overflow-x-visible md:pr-8 md:mt-14 px-4 md:px-auto"
+          class="w-full prose prose-xl max-w-4xl dark:bg-primary-black dark:prose-invert overflow-y-auto overflow-x-visible md:pr-8 md:mt-14 px-4 md:px-auto custom-scrollbar"
           phx-hook="Docs"
         >
           <div id="module-docs" class="w-full nav-anchor text-black dark:text-white relative py-4 md:py-auto">

--- a/lib/ash_hq_web/pages/docs.ex
+++ b/lib/ash_hq_web/pages/docs.ex
@@ -102,7 +102,7 @@ defmodule AshHqWeb.Pages.Docs do
         />
         <div
           id="docs-window"
-          class="w-full prose prose-xl max-w-5xl dark:bg-primary-black dark:prose-invert overflow-y-auto overflow-x-visible md:pr-8 md:mt-14 px-4 md:px-auto"
+          class="w-full prose prose-xl max-w-4xl dark:bg-primary-black dark:prose-invert overflow-y-auto overflow-x-visible md:pr-8 md:mt-14 px-4 md:px-auto"
           phx-hook="Docs"
         >
           <div id="module-docs" class="w-full nav-anchor text-black dark:text-white relative py-4 md:py-auto">

--- a/lib/ash_hq_web/pages/docs.ex
+++ b/lib/ash_hq_web/pages/docs.ex
@@ -81,10 +81,10 @@ defmodule AshHqWeb.Pages.Docs do
           />
         </div>
       </span>
-      <div class="grow w-full overflow-hidden flex flex-row h-full justify-center md:space-x-12 bg-white dark:bg-primary-black">
+      <div class="grow w-screen overflow-hidden flex flex-row h-full justify-between md:space-x-12 bg-white dark:bg-primary-black">
         <DocSidebar
           id="sidebar"
-          class="hidden xl:block mt-10"
+          class="hidden xl:block pt-10 w-80 overflow-x-hidden border-r"
           change_version={@change_version}
           add_version={@add_version}
           remove_version={@remove_version}
@@ -102,7 +102,7 @@ defmodule AshHqWeb.Pages.Docs do
         />
         <div
           id="docs-window"
-          class="w-full prose prose-xl max-w-6xl dark:bg-primary-black dark:prose-invert overflow-y-auto overflow-x-visible md:pr-8 md:mt-14 px-4 md:px-auto"
+          class="w-full prose prose-xl max-w-5xl dark:bg-primary-black dark:prose-invert overflow-y-auto overflow-x-visible md:pr-8 md:mt-14 px-4 md:px-auto"
           phx-hook="Docs"
         >
           <div id="module-docs" class="w-full nav-anchor text-black dark:text-white relative py-4 md:py-auto">
@@ -256,7 +256,7 @@ defmodule AshHqWeb.Pages.Docs do
           </div>
         </div>
         {#if @module}
-          <div class="w-min overflow-y-auto overflow-x-visible mt-14 dark:bg-primary-black bg-opacity-70">
+          <div class="lg:w-64 overflow-y-auto overflow-x-visible mt-14 dark:bg-primary-black bg-opacity-70">
             <RightNav functions={@module.functions} module={@module.name} />
           </div>
         {#else}


### PR DESCRIPTION
* Adjusted spacing between the sidebars and main docs to maintain consistent width regardless of the content
* Added a custom scrollbar

## Before
<img width="1727" alt="Screenshot 2022-09-07 at 10 47 00 AM" src="https://user-images.githubusercontent.com/22826580/188908677-f69a1228-8764-485a-978d-292f53f84d99.png">

## After
<img width="1725" alt="Screenshot 2022-09-07 at 10 47 12 AM" src="https://user-images.githubusercontent.com/22826580/188909070-d3c8f663-0622-468c-910a-dcc45cb21abb.png">

