### PR TITLE
style: right sidebar spacing and left sidebar colors

### DIFF
--- a/lib/ash_hq_web/components/doc_sidebar.ex
+++ b/lib/ash_hq_web/components/doc_sidebar.ex
@@ -27,7 +27,7 @@ defmodule AshHqWeb.Components.DocSidebar do
     ~F"""
     <aside
       id={@id}
-      class={"grid h-full overflow-y-auto pb-36 w-fit z-40 bg-white dark:bg-primary-black", @class}
+      class={"grid h-full overflow-y-auto pb-36 pl-2 w-fit z-40", @class}
       aria-label="Sidebar"
     >
       <div class="flex flex-col">

--- a/lib/ash_hq_web/pages/docs.ex
+++ b/lib/ash_hq_web/pages/docs.ex
@@ -258,7 +258,7 @@ defmodule AshHqWeb.Pages.Docs do
           </div>
         </div>
         {#if @module}
-          <div class="lg:w-64 overflow-y-auto overflow-x-hidden dark:bg-primary-black bg-opacity-70">
+          <div class="lg:w-full lg:max-w-sm overflow-y-auto overflow-x-hidden dark:bg-primary-black bg-opacity-70">
             <RightNav functions={@module.functions} module={@module.name} />
           </div>
         {#else}

--- a/lib/ash_hq_web/pages/docs.ex
+++ b/lib/ash_hq_web/pages/docs.ex
@@ -82,7 +82,7 @@ defmodule AshHqWeb.Pages.Docs do
         </div>
       </span>
       <div class="grow w-screen overflow-hidden flex flex-row h-full justify-between md:space-x-12 bg-white dark:bg-primary-black">
-        <div class="lg:border-r lg:pr-2 lg:pt-14">
+        <div class="lg:border-r lg:pr-2 lg:pt-14 bg-gray-100 dark:bg-gray-900">
           <DocSidebar
             id="sidebar"
             class="hidden xl:block w-80 overflow-x-hidden custom-scrollbar"


### PR DESCRIPTION
Moved the right sidebar closer to the main docs content and changed the left sidebar colors slightly.

## Before
<img width="1727" alt="Screenshot 2022-09-07 at 2 49 19 PM" src="https://user-images.githubusercontent.com/22826580/188955320-106befff-cf82-4378-9b35-20be3714ec30.png">

## After
<img width="1727" alt="Screenshot 2022-09-07 at 2 49 06 PM" src="https://user-images.githubusercontent.com/22826580/188955345-467895ff-8658-4c63-8f69-b116ae2b28bb.png">
