### PR TITLE
fix: download user agent db in setup task

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -115,7 +115,7 @@ defmodule AshHq.MixProject do
   defp aliases do
     [
       seed: ["run priv/repo/seeds.exs"],
-      setup: ["ash_postgres.create", "ash_postgres.migrate", "seed"],
+      setup: ["ash_postgres.create", "ash_postgres.migrate", "seed", "ua_inspector.download --force"],
       reset: ["drop", "setup"],
       credo: "credo --strict",
       drop: ["ash_postgres.drop"],


### PR DESCRIPTION
While setting up a local dev instance of ash_hq, I ran into errors due to the UAInspector DB not being downloaded automatically.

This PR adds a command to the setup task alias to download the required files (per instructions at https://github.com/elixir-inspector/ua_inspector#database-download).
Not sure if it is better as part of the `setup` task or just a documented step in the README.md ?

 