### PR TITLE
chore: Add nodejs 18 (LTS) to .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 elixir 1.14.0
+nodejs 18.12.0


### PR DESCRIPTION
This PR adds nodejs to the ASDF `.tool-versions` file to fix an error at startup if there isn't a global nodejs installed:

```
iex -S mix phx.server
Erlang/OTP 25 [erts-13.0.4] [source] [64-bit] [smp:10:10] [ds:10:10:10] [async-threads:1] [jit]

[notice]     :alarm_handler: {:set, {:system_memory_high_watermark, []}}
[info] Running AshHqWeb.Endpoint with cowboy 2.9.0 at 127.0.0.1:4000 (http)
[info] Access AshHqWeb.Endpoint at http://localhost:4000
Interactive Elixir (1.14.0) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> No version is set for command npx
Consider adding one of the following versions in your config file at /Users/michaelbuhot/src/ash-project/ash_hq/.tool-versions
nodejs 14.17.0
nodejs 16.17.0
nodejs lts
nodejs 16.18.0
nodejs 18.12.0
[watch] build finished, watching for changes...
[error] Task #PID<0.907.0> started from AshHqWeb.Endpoint terminating
** (stop) :watcher_command_error
    (phoenix 1.6.14) lib/phoenix/endpoint/watcher.ex:55: Phoenix.Endpoint.Watcher.watch/2
    (elixir 1.14.0) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2
    (stdlib 4.0.1) proc_lib.erl:240: :proc_lib.init_p_do_apply/3
Function: &Phoenix.Endpoint.Watcher.watch/2
    Args: ["npx", ["tailwindcss", "--input=css/app.css", "--output=../priv/static/assets/app.css", "--postcss", "--watch", {:cd, "/Users/michaelbuhot/src/ash-project/ash_hq/assets"}]]
```