### PR TITLE
feat(DocSidebar): Extract TreeView component to improve consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ ash_hq-*.tar
 
 # Ignore assets that are produced by build tools.
 /priv/static/assets/
+/assets/css/_components.css
+/assets/js/_hooks/
 
 # Ignore digested assets cache.
 /priv/static/cache_manifest.json

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -5,6 +5,9 @@
 
 @import "syntax.css";
 
+/* Import scoped CSS rules for components */
+@import "./_components.css";
+
 .search-hit {
   color: #fb923c;
 }

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -63,6 +63,7 @@ config :ash_hq, AshHqWeb.Endpoint,
 
 # Watch static and templates for browser reloading.
 config :ash_hq, AshHqWeb.Endpoint,
+  reloadable_compilers: [:gettext, :elixir, :surface],
   live_reload: [
     patterns: [
       ~r"priv/static/.*(js|css|png|jpeg|jpg|gif|svg)$",

--- a/lib/ash_hq_web/components/doc_sidebar.ex
+++ b/lib/ash_hq_web/components/doc_sidebar.ex
@@ -3,10 +3,8 @@ defmodule AshHqWeb.Components.DocSidebar do
   use Surface.Component
 
   alias AshHqWeb.DocRoutes
-  alias Surface.Components.LivePatch
+  alias AshHqWeb.Components.TreeView
   alias Phoenix.LiveView.JS
-
-  import Tails
 
   prop class, :css_class, default: ""
   prop libraries, :list, required: true
@@ -90,240 +88,50 @@ defmodule AshHqWeb.Components.DocSidebar do
           selected_versions={@selected_versions}
         />
       </div>
-      <div class="py-3 px-3">
-        <ul class="space-y-2">
-          <div>
-            Guides
-          </div>
-          {#for {category, guides_by_library} <- @guides_by_category_and_library}
-            <div class="text-base-light-500">
-              <button
-                phx-click={collapse("#{@id}-#{String.replace(category, " ", "-")}")}
-                class="flex flex-row items-center"
-              >
-                <div id={"#{@id}-#{String.replace(category, " ", "-")}-chevron-down"}>
-                  <Heroicons.Outline.ChevronDownIcon class="w-3 h-3 mr-1" />
-                </div>
-                <div
-                  id={"#{@id}-#{String.replace(category, " ", "-")}-chevron-right"}
-                  class="-rotate-90"
-                  style="display: none;"
-                >
-                  <Heroicons.Outline.ChevronDownIcon class="w-3 h-3 mr-1" />
-                </div>
-                <div>{category}</div>
-              </button>
-            </div>
-            <div id={"#{@id}-#{String.replace(category, " ", "-")}"}>
-              {#for {library, guides} <- guides_by_library}
-                <li class="ml-3 text-base-light-400 p-1">
-                  {library}
-                  <ul>
-                    {#for guide <- guides}
-                      <li class="ml-1">
-                        <LivePatch
-                          to={DocRoutes.doc_link(guide, @selected_versions)}
-                          class={
-                            "flex items-center p-1 text-base font-normal text-base-light-900 rounded-lg dark:text-base-dark-200 hover:bg-base-light-100 dark:hover:bg-base-dark-700",
-                            "bg-base-light-300 dark:bg-base-dark-600": @guide && @guide.id == guide.id
-                          }
-                        >
-                          <Heroicons.Outline.BookOpenIcon class="h-4 w-4" />
-                          <span class="ml-3 mr-2">{guide.name}</span>
-                        </LivePatch>
-                      </li>
-                    {/for}
-                  </ul>
-                </li>
-              {/for}
-            </div>
-          {/for}
-          <div class="mt-4">
-            Reference
-          </div>
-          <div class="ml-2 space-y-2">
-            {#if !Enum.empty?(@extensions)}
-              <div class="text-base-light-500">
-                <button phx-click={collapse("#{@id}-extension")} class="flex flex-row items-center">
-                  <div id={"#{@id}-extension-chevron-down"}>
-                    <Heroicons.Outline.ChevronDownIcon class="w-3 h-3 mr-1" />
-                  </div>
-                  <div id={"#{@id}-extension-chevron-right"} class="-rotate-90" style="display: none;">
-                    <Heroicons.Outline.ChevronDownIcon class="w-3 h-3 mr-1" />
-                  </div>
-                  Extensions
-                </button>
-              </div>
-            {/if}
-            <div id={"#{@id}-extension"}>
-              {#for {library, extensions} <- @extensions}
-                <li class="ml-3 text-base-light-200 p-1">
-                  {library}
-                  <ul>
-                    {#for extension <- extensions}
-                      <li class="ml-1">
-                        <LivePatch
-                          to={DocRoutes.doc_link(extension, @selected_versions)}
-                          class="flex items-center p-1 text-base font-normal text-base-light-900 rounded-lg dark:text-base-dark-200 hover:bg-base-light-100 dark:hover:bg-base-dark-700"
-                        >
-                          {render_icon(assigns, extension.type)}
-                          <span class="ml-3 mr-2">{extension.name}</span>
-                        </LivePatch>
-                        {#if @extension && @extension.id == extension.id && !Enum.empty?(extension.dsls)}
-                          {render_dsls(assigns, extension.dsls, [])}
-                        {/if}
-                      </li>
-                    {/for}
-                  </ul>
-                </li>
-              {/for}
-            </div>
-
-            {#if !Enum.empty?(@mix_tasks_by_category)}
-              <div class="text-base-light-500">
-                <button phx-click={collapse("#{@id}-mix-tasks")} class="flex flex-row items-center">
-                  <div id={"#{@id}-mix-tasks-chevron-down"}>
-                    <Heroicons.Outline.ChevronDownIcon class="w-3 h-3 mr-1" />
-                  </div>
-                  <div id={"#{@id}-mix-tasks-chevron-right"} class="-rotate-90" style="display: none;">
-                    <Heroicons.Outline.ChevronDownIcon class="w-3 h-3 mr-1" />
-                  </div>
-                  Mix Tasks
-                </button>
-              </div>
-            {/if}
-            <div id={"#{@id}-mix-tasks"}>
-              {#for {category, mix_tasks} <- @mix_tasks_by_category}
-                <div class="ml-4">
-                  <span class="text-sm text-base-light-900 dark:text-base-dark-100">{category}</span>
-                </div>
-                {#for mix_task <- mix_tasks}
-                  <li class="ml-4">
-                    <LivePatch
-                      to={DocRoutes.doc_link(mix_task, @selected_versions)}
-                      class="flex items-center space-x-2 pt-1 text-base font-normal text-base-light-900 rounded-lg dark:text-base-dark-100 hover:bg-base-light-100 dark:hover:bg-base-light-700"
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke-width="1.5"
-                        stroke="currentColor"
-                        class="w-4 h-4"
-                      >
-                        <path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          d="M6.75 7.5l3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0021 18V6a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6v12a2.25 2.25 0 002.25 2.25z"
-                        />
-                      </svg>
-                      <span class="">{mix_task.name}</span>
-                    </LivePatch>
-                  </li>
-                {/for}
-              {/for}
-            </div>
-
-            <div class="text-base-light-500">
-              <button phx-click={collapse("#{@id}-modules")} class="flex flex-row items-center">
-                <div id={"#{@id}-modules-chevron-down"}>
-                  <Heroicons.Outline.ChevronDownIcon class="w-3 h-3 mr-1" />
-                </div>
-                <div id={"#{@id}-modules-chevron-right"} class="-rotate-90" style="display: none;">
-                  <Heroicons.Outline.ChevronDownIcon class="w-3 h-3 mr-1" />
-                </div>
-                Modules
-              </button>
-            </div>
-            <div id={"#{@id}-modules"}>
-              {#for {category, modules} <- @modules_by_category}
-                <div class="ml-4">
-                  <span class="text-sm text-base-light-900 dark:text-base-dark-100">{category}</span>
-                </div>
-                {#for module <- modules}
-                  <li class="ml-4">
-                    <LivePatch
-                      to={DocRoutes.doc_link(module, @selected_versions)}
-                      class="flex items-center space-x-2 pt-1 text-base font-normal text-base-light-900 rounded-lg dark:text-base-dark-100 hover:bg-base-light-100 dark:hover:bg-base-light-700"
-                    >
-                      <Heroicons.Outline.CodeIcon class="h-4 w-4" />
-                      <span class="">{module.name}</span>
-                    </LivePatch>
-                  </li>
-                {/for}
-              {/for}
-            </div>
-          </div>
-        </ul>
-      </div>
+      <TreeView
+        id={"#{@id}-sidebar-treeview"}
+        render_icon={&icon/1}
+        items={treeview_items(
+          @selected_versions,
+          @guide,
+          @extension,
+          @dsl,
+          @mix_task,
+          @module,
+          @guides_by_category_and_library,
+          @extensions,
+          @mix_tasks_by_category,
+          @modules_by_category
+        )}
+      />
     </aside>
     """
   end
 
-  defp render_dsls(assigns, dsls, path) do
+  def icon(assigns) do
     ~F"""
-    <ul class="ml-1 flex flex-col">
-      {#for dsl <- Enum.filter(dsls, &(&1.path == path))}
-        <li class="border-l pl-1 border-primary-light-600 border-opacity-30">
-          <div class="flex flex-row items-center">
-            <LivePatch
-              to={DocRoutes.doc_link(dsl, @selected_versions)}
-              class={classes([
-                "flex items-center p-1 font-normal rounded-lg text-black dark:text-white hover:text-primary-light-300",
-                "text-primary-light-600 dark:text-primary-dark-400 font-bold":
-                  @dsl &&
-                    List.starts_with?(@dsl.path ++ [@dsl.name], path ++ [dsl.name])
-              ])}
-            >
-              {dsl.name}
-            </LivePatch>
-          </div>
-          {render_dsls(assigns, dsls, path ++ [dsl.name])}
-        </li>
-      {/for}
-    </ul>
-    """
-  end
-
-  def render_icon(assigns, "Resource") do
-    ~F"""
-    <Heroicons.Outline.ServerIcon class="h-4 w-4" />
-    """
-  end
-
-  def render_icon(assigns, "Api") do
-    ~F"""
-    <Heroicons.Outline.SwitchHorizontalIcon class="h-4 w-4" />
-    """
-  end
-
-  def render_icon(assigns, "DataLayer") do
-    ~F"""
-    <Heroicons.Outline.DatabaseIcon class="h-4 w-4" />
-    """
-  end
-
-  def render_icon(assigns, "Flow") do
-    ~F"""
-    <Heroicons.Outline.MapIcon class="h-4 w-4" />
-    """
-  end
-
-  def render_icon(assigns, "Notifier") do
-    ~F"""
-    <Heroicons.Outline.MailIcon class="h-4 w-4" />
-    """
-  end
-
-  def render_icon(assigns, "Registry") do
-    ~F"""
-    <Heroicons.Outline.ViewListIcon class="h-4 w-4" />
-    """
-  end
-
-  def render_icon(assigns, _) do
-    ~F"""
-    <Heroicons.Outline.PuzzleIcon class="h-4 w-4" />
+    {#case @name}
+      {#match "Guide"}
+        <Heroicons.Outline.BookOpenIcon class={@class} />
+      {#match "Resource"}
+        <Heroicons.Outline.ServerIcon class={@class} />
+      {#match "Api"}
+        <Heroicons.Outline.SwitchHorizontalIcon class={@class} />
+      {#match "DataLayer"}
+        <Heroicons.Outline.DatabaseIcon class={@class} />
+      {#match "Flow"}
+        <Heroicons.Outline.MapIcon class={@class} />
+      {#match "Notifier"}
+        <Heroicons.Outline.MailIcon class={@class} />
+      {#match "Registry"}
+        <Heroicons.Outline.ViewListIcon class={@class} />
+      {#match "Code"}
+        <Heroicons.Outline.CodeIcon class={@class} />
+      {#match "Mix Task"}
+        <Heroicons.Outline.TerminalIcon class={@class} />
+      {#match _}
+        <Heroicons.Outline.PuzzleIcon class={@class} />
+    {/case}
     """
   end
 
@@ -479,10 +287,184 @@ defmodule AshHqWeb.Components.DocSidebar do
     )
   end
 
-  defp collapse(id, js \\ %JS{}) do
-    js
-    |> JS.toggle(to: "##{id}", time: 0)
-    |> JS.toggle(to: "##{id}-chevron-down", time: 0)
-    |> JS.toggle(to: "##{id}-chevron-right", time: 0)
+  defp treeview_items(
+         selected_versions,
+         selected_guide,
+         selected_extension,
+         selected_dsl,
+         selected_mix_task,
+         selected_module,
+         guides_by_category_and_library,
+         extensions,
+         mix_tasks_by_category,
+         modules_by_category
+       ) do
+    text_styles = "text-base-light-900 dark:text-base-dark-200"
+
+    guides = %TreeView.Item{
+      name: "guides",
+      label: "Guides",
+      collapsable: false,
+      items:
+        Enum.map(guides_by_category_and_library, fn {category, by_library} ->
+          %TreeView.Item{
+            name: slug(category),
+            label: category,
+            collapsable: true,
+            class: "text-base-light-500",
+            items:
+              Enum.map(by_library, fn {library, guides} ->
+                %TreeView.Item{
+                  name: slug(library),
+                  label: library,
+                  collapsable: true,
+                  class: "text-base-light-400",
+                  items:
+                    Enum.map(guides, fn guide ->
+                      %TreeView.Item{
+                        name: slug(guide.name),
+                        label: guide.name,
+                        icon: "Guide",
+                        selected: selected_guide && selected_guide.id == guide.id,
+                        link: [patch: DocRoutes.doc_link(guide, selected_versions)],
+                        class: text_styles
+                      }
+                    end)
+                }
+              end)
+          }
+        end)
+    }
+
+    extensions = %TreeView.Item{
+      name: "extensions",
+      label: "Extensions",
+      collapsable: true,
+      collapsed: !selected_extension,
+      class: "text-base-light-500",
+      items:
+        Enum.map(extensions, fn {library, extensions} ->
+          %TreeView.Item{
+            name: slug(library),
+            label: library,
+            collapsable: true,
+            class: "text-base-light-400",
+            items:
+              Enum.map(extensions, fn extension ->
+                items = dsl_tree_view_items(selected_versions, extension.dsls, selected_dsl, [])
+
+                %TreeView.Item{
+                  name: slug(extension.name),
+                  label: extension.name,
+                  icon: extension.type,
+                  collapsable: items != [],
+                  collapsed: !(selected_extension && selected_extension.id == extension.id),
+                  link: [patch: DocRoutes.doc_link(extension, selected_versions)],
+                  selected: (selected_extension && !selected_dsl) && selected_extension.id == extension.id,
+                  items: items,
+                  indent_guide: true,
+                  class: text_styles
+                }
+              end)
+          }
+        end)
+    }
+
+    mix_tasks = %TreeView.Item{
+      name: "mix-tasks",
+      label: "Mix Tasks",
+      collapsable: true,
+      collapsed: !selected_mix_task,
+      class: "text-base-light-500",
+      items:
+        Enum.map(mix_tasks_by_category, fn {category, mix_tasks} ->
+          %TreeView.Item{
+            name: slug(category),
+            label: category,
+            collapsable: true,
+            class: "text-base-light-400",
+            items:
+              Enum.map(mix_tasks, fn mix_task ->
+                %TreeView.Item{
+                  name: slug(mix_task.name),
+                  label: mix_task.name,
+                  icon: "Mix Task",
+                  link: [patch: DocRoutes.doc_link(mix_task, selected_versions)],
+                  selected: selected_mix_task && selected_mix_task.id == mix_task.id,
+                  class: text_styles
+                }
+              end)
+          }
+        end)
+    }
+
+    modules = %TreeView.Item{
+      name: "modules",
+      label: "Modules",
+      collapsable: true,
+      collapsed: !selected_module,
+      class: "text-base-light-500",
+      items:
+        Enum.map(modules_by_category, fn {category, modules} ->
+          %TreeView.Item{
+            name: slug(category),
+            label: category,
+            collapsable: true,
+            class: "text-base-light-400",
+            items:
+              Enum.map(modules, fn module ->
+                %TreeView.Item{
+                  name: slug(module.name),
+                  label: module.name,
+                  icon: "Code",
+                  link: [patch: DocRoutes.doc_link(module, selected_versions)],
+                  selected: selected_module && selected_module.id == module.id,
+                  class: text_styles
+                }
+              end)
+          }
+        end)
+    }
+
+    reference = %TreeView.Item{
+      name: "reference",
+      label: "Reference",
+      collapsable: false,
+      items: [
+        extensions,
+        mix_tasks,
+        modules
+      ]
+    }
+
+    [
+      guides,
+      reference
+    ]
+  end
+
+  defp dsl_tree_view_items(selected_versions, dsls, selected_dsl, path) do
+    dsls
+    |> Enum.filter(&(&1.path == path))
+    |> Enum.map(fn dsl ->
+      items = dsl_tree_view_items(selected_versions, dsls, selected_dsl, path ++ [dsl.name])
+
+      %TreeView.Item{
+        name: slug(dsl.name),
+        label: dsl.name,
+        collapsable: false,
+        selected: selected_dsl && selected_dsl.id == dsl.id,
+        link: [patch: DocRoutes.doc_link(dsl, selected_versions)],
+        items: items,
+        indent_guide: true
+      }
+    end)
+  end
+
+  def slug(string) do
+    string
+    |> String.downcase()
+    |> String.replace(" ", "_")
+    |> String.replace(~r/[^a-z0-9-_]/, "-")
   end
 end

--- a/lib/ash_hq_web/components/search.ex
+++ b/lib/ash_hq_web/components/search.ex
@@ -204,7 +204,9 @@ defmodule AshHqWeb.Components.Search do
         """
 
       type when type in ["Dsl", "Option"] ->
-        AshHqWeb.Components.DocSidebar.render_icon(assigns, item.extension_type)
+        ~F"""
+        <AshHqWeb.Components.DocSidebar.icon name={item.extension_type}, class="h-4 w-4" />
+        """
 
       "Guide" ->
         ~F"""

--- a/lib/ash_hq_web/components/tree_view.ex
+++ b/lib/ash_hq_web/components/tree_view.ex
@@ -1,0 +1,177 @@
+defmodule AshHqWeb.Components.TreeView do
+  @moduledoc """
+  A tree view with collapsable nodes.
+
+  The component must be supplied with a list of `%Item{}` structs defining
+  the behaviour of each node in the tree.
+  """
+
+  use Surface.Component
+  alias Phoenix.LiveView.JS
+
+  defmodule Item do
+    @moduledoc """
+    Data for an item in the TreeView.
+
+    name: required - logical name for the tree view item. Used to build the DOM id.
+    label: text to display for the item.
+    link: props to forward to the `<.link/>` component, eg `[patch: ~p"/documents/123"]`
+    items: child items
+    icon: name prop to pass to the TreeView's render_icon component
+    collapsable: when true, allows the item's children to be hidden
+    collapsed: the initial collapsed state of the children items list
+    selected: the initial selection state of the item
+    indent_guide: When true, displays an indentation guide to align deeply nested items
+    class: any additional classes to add to the `<li>` element for the item
+    """
+    defstruct name: nil,
+              label: "",
+              link: nil,
+              items: nil,
+              icon: nil,
+              collapsable: false,
+              collapsed: false,
+              selected: false,
+              indent_guide: false,
+              class: nil
+
+    def has_children?(%{items: items}), do: items not in [nil, []]
+  end
+
+  @doc "DOM id for the outer div"
+  prop id, :string, required: true
+
+  @doc "Items to display in the TreeView"
+  prop items, :list, required: true
+
+  @doc "A function component accepting props for `name` and `class`"
+  prop render_icon, :any, required: true
+
+  @doc "Any additional CSS classes to add to the outer div"
+  prop class, :css_class
+
+  def render(assigns) do
+    ~F"""
+    <style>
+      .treeview :deep(.selected) {
+      @apply bg-base-light-300;
+      }
+      :global(.dark) .treeview :deep(.selected) {
+      @apply bg-base-dark-600;
+      }
+    </style>
+    <div id={@id} class={"treeview py-3 px-3", @class}>
+      <ul class="space-y-4">
+        <li :for={item <- @items} class={item.class}>
+          <.item item={item} path={@id} render_icon={@render_icon} root={@id} />
+        </li>
+      </ul>
+    </div>
+    """
+  end
+
+  defp item(%{item: %Item{}} = assigns) do
+    ~F"""
+    <div
+      id={"#{@path}-#{@item.name}"}
+      class={
+        "rounded-lg hover:bg-base-light-100 dark:hover:bg-base-dark-700",
+        selected: @item.selected
+      }
+    >
+      <.item_button item={@item} path={@path} render_icon={@render_icon} root={@root} />
+    </div>
+    <ul
+      :if={Item.has_children?(@item)}
+      id={"#{@path}-#{@item.name}-items"}
+      class={"pl-2", hidden: @item.collapsed}
+    >
+      <li :for={item <- @item.items}
+        class={
+          item.class,
+          "pt-2": Item.has_children?(item),
+          "border-l pl-1 border-primary-light-600 border-opacity-30": @item.indent_guide
+        }
+      >
+        <.item item={item} path={"#{@path}-#{@item.name}"} render_icon={@render_icon} root={@root} />
+      </li>
+    </ul>
+    """
+  end
+
+  defp item_button(assigns) do
+    ~F"""
+    <button
+      phx-click={maybe_collapse(@item, @path) |> maybe_link(@item, @path, @root)}
+      class="flex flex-row items-center w-full"
+    >
+      <.chevron item={@item} path={@path} />
+      <.icon item={@item} render_icon={@render_icon} />
+      <span class="ml-1">{@item.label}</span>
+    </button>
+    """
+  end
+
+  defp chevron(assigns) do
+    ~F"""
+    <div
+      :if={@item.collapsable}
+      id={"#{@path}-#{@item.name}-chevron"}
+      class={
+        "motion-safe:transition-transform motion-safe:duration-200",
+        "-rotate-90": @item.collapsed
+      }
+    >
+      <Heroicons.Outline.ChevronDownIcon class="w-3 h-3 mr-1" />
+    </div>
+    """
+  end
+
+  defp icon(assigns) do
+    ~F"""
+    {#if @item.icon}
+      {@render_icon.(assign(assigns, name: @item.icon, class: "w-4 h-4 flex-none"))}
+    {/if}
+    """
+  end
+
+  defp maybe_collapse(js \\ %JS{}, item, path) do
+    if item.collapsable,
+      do: toggle_collapsed(js, "#{path}-#{item.name}"),
+      else: js
+  end
+
+  defp maybe_link(js, %{link: nil}, _path, _root), do: js
+
+  defp maybe_link(js, item, path, root) do
+    cond do
+      Keyword.has_key?(item.link, :patch) -> JS.patch(js, item.link[:patch])
+      Keyword.has_key?(item.link, :navigate) -> JS.navigate(js, item.link[:navigate])
+    end
+    |> update_selection("#{path}-#{item.name}", root)
+  end
+
+  defp toggle_collapsed(js, id) do
+    js
+    |> toggle_class("hidden", to: "##{id}-items")
+    |> toggle_class("-rotate-90", to: "##{id}-chevron")
+  end
+
+  defp toggle_class(js, class, to: selector) do
+    classes =
+      class
+      |> String.split(" ")
+      |> Enum.map(&String.replace(&1, ":", "\\:"))
+      |> Enum.map(fn class -> ".#{class}" end)
+
+    js
+    |> JS.add_class(class, to: "#{selector}:not(#{Enum.join(classes, ", ")})")
+    |> JS.remove_class(class, to: "#{selector}#{Enum.join(classes, "")}")
+  end
+
+  defp update_selection(js, id, root) do
+    js
+    |> JS.add_class("selected", to: "##{id}")
+    |> JS.remove_class("selected", to: "##{root} .selected")
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule AshHq.MixProject do
       version: "0.1.0",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
-      compilers: Mix.compilers(),
+      compilers: Mix.compilers() ++ [:surface],
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps()


### PR DESCRIPTION
Fixes #33 

With the TreeView component, the behaviour of each node can be controlled with options for collapsable, indent_guide, icon, link, etc.

The sidebar looks roughly the same, with some improvements to spacing and some items can be collapsed now where the couldn't previously.

---

By default the reference section is collapsed, with the guides section expanded:

<img width="334" alt="image" src="https://user-images.githubusercontent.com/336840/200499260-3dc6d6a6-eb0b-4b36-bf12-96aea2e3c8b4.png">

The extensions now include the chevron icon to indicate they can be expanded:

<img width="304" alt="image" src="https://user-images.githubusercontent.com/336840/200499438-fd90b2de-120c-4f56-9146-78e7c03d6e34.png">

Selection works uniformly throughout, so the previous behaviour of bolding all nodes on the path to the currently selected DSL is lost. (It can be added this back in if desired):

<img width="307" alt="image" src="https://user-images.githubusercontent.com/336840/200499774-fd47aa7f-2704-4403-9aed-7177fb093f06.png">


