### PR TITLE
chore: Update bug issue template to use valid Markdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -6,12 +6,15 @@ labels:  bug, needs review
 assignees: ''
 ---
 
-** Brief Description **
+**Brief Description**
+
 A brief description of the issue
 
-** Steps to reproduce the bug **
-High level purpose of the extension.
+**Steps to reproduce the bug**
 
-** Context **
+A step-by-step guide on how to reproduce the bug
+
+**Context**
+
 Pictures or videos of the issue occurring
 


### PR DESCRIPTION
When previewing the generated text, it rendered as `** Brief Description **`, etc.

Also tidied up filename and updated the description for the steps (was leftover from copying from a previous issue template)