### PR TITLE
fix: Only start Nostrum when the Discord bot is enabled

### DIFF
--- a/lib/ash_hq/application.ex
+++ b/lib/ash_hq/application.ex
@@ -18,6 +18,7 @@ defmodule AshHq.Application do
 
     discord_bot =
       if Application.get_env(:ash_hq, :discord_bot) do
+        Nostrum.Application.start(:normal, [])
         [AshHq.Discord.Supervisor]
       else
         []

--- a/mix.exs
+++ b/mix.exs
@@ -50,7 +50,7 @@ defmodule AshHq.MixProject do
       {:ash_blog, github: "ash-project/ash_blog"},
       {:ash_csv, github: "ash-project/ash_csv"},
       # Discord
-      {:nostrum, github: "zachdaniel/nostrum"},
+      {:nostrum, github: "zachdaniel/nostrum", runtime: false},
       {:cowlib, "~> 2.11", hex: :remedy_cowlib, override: true},
       # UI
       {:tails, "~> 0.1"},


### PR DESCRIPTION
By default Mix will start the applications in all dependencies, which in this case will raise an error if there isn't a valid Discord bot token set.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
