### PR TITLE
improvement: Table of Contents for guides

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -32,6 +32,7 @@
     item_type: 1,
     sanitized_name_attribute: 1,
     show_docs_on: 1,
-    header_ids?: 1
+    header_ids?: 1,
+    table_of_contents?: 1
   ]
 ]

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -37,4 +37,15 @@ module.exports = {
     require("@tailwindcss/forms"),
     require("@tailwindcss/line-clamp"),
   ],
+  safelist: [
+    // Used in Table of Contents generation, which is stored in the DB and cannot be
+    // checked at build time.
+    "m-0",
+    "w-[20em]",
+    "float-right",
+    "list-[lower-alpha]",
+    "border-base-light-300",
+    "dark:border-base-dark-600",
+    "ml-8",
+  ],
 };

--- a/lib/ash_hq/docs/extensions/render_markdown/changes/render_markdown.ex
+++ b/lib/ash_hq/docs/extensions/render_markdown/changes/render_markdown.ex
@@ -57,7 +57,8 @@ defmodule AshHq.Docs.Extensions.RenderMarkdown.Changes.RenderMarkdown do
                libraries,
                current_library,
                current_module,
-               AshHq.Docs.Extensions.RenderMarkdown.header_ids?(changeset.resource)
+               AshHq.Docs.Extensions.RenderMarkdown.header_ids?(changeset.resource),
+               AshHq.Docs.Extensions.RenderMarkdown.table_of_contents?(changeset.resource)
              ) do
           {:error, html_doc, error_messages} ->
             Logger.warn("""

--- a/lib/ash_hq/docs/extensions/render_markdown/post_processor.ex
+++ b/lib/ash_hq/docs/extensions/render_markdown/post_processor.ex
@@ -1,0 +1,21 @@
+defmodule AshHq.Docs.Extensions.RenderMarkdown.PostProcessor do
+  @moduledoc """
+  Takes a HTML document or a list of HTML documents, and runs a set of HTML
+  post-processor transformations on them.
+  """
+
+  def run(html, libraries, current_library, current_module) when is_list(html) do
+    Enum.map(html, &run(&1, libraries, current_library, current_module))
+  end
+
+  def run(html, libraries, current_library, current_module) do
+    html
+    |> Floki.parse_document!()
+    |> AshHq.Docs.Extensions.RenderMarkdown.PostProcessors.Highlighter.highlight(
+      libraries,
+      current_library,
+      current_module
+    )
+    |> AshHq.Docs.Extensions.RenderMarkdown.RawHTML.raw_html(pretty: true)
+  end
+end

--- a/lib/ash_hq/docs/extensions/render_markdown/post_processor.ex
+++ b/lib/ash_hq/docs/extensions/render_markdown/post_processor.ex
@@ -4,7 +4,12 @@ defmodule AshHq.Docs.Extensions.RenderMarkdown.PostProcessor do
   post-processor transformations on them.
   """
 
-  alias AshHq.Docs.Extensions.RenderMarkdown.PostProcessors.{HeadingAutolinker, Highlighter}
+  alias AshHq.Docs.Extensions.RenderMarkdown.PostProcessors.{
+    HeadingAutolinker,
+    Highlighter,
+    TableOfContentsGenerator
+  }
+
   alias AshHq.Docs.Extensions.RenderMarkdown.RawHTML
 
   def run(html, libraries, current_library, current_module, add_ids?, add_table_of_contents?)
@@ -15,10 +20,11 @@ defmodule AshHq.Docs.Extensions.RenderMarkdown.PostProcessor do
     )
   end
 
-  def run(html, libraries, current_library, current_module, add_ids?, _add_table_of_contents?) do
+  def run(html, libraries, current_library, current_module, add_ids?, add_table_of_contents?) do
     html
     |> Floki.parse_document!()
     |> HeadingAutolinker.autolink(add_ids?)
+    |> TableOfContentsGenerator.generate(add_table_of_contents?)
     |> Highlighter.highlight(libraries, current_library, current_module)
     |> RawHTML.raw_html(pretty: true)
   end

--- a/lib/ash_hq/docs/extensions/render_markdown/post_processor.ex
+++ b/lib/ash_hq/docs/extensions/render_markdown/post_processor.ex
@@ -4,18 +4,22 @@ defmodule AshHq.Docs.Extensions.RenderMarkdown.PostProcessor do
   post-processor transformations on them.
   """
 
-  def run(html, libraries, current_library, current_module) when is_list(html) do
-    Enum.map(html, &run(&1, libraries, current_library, current_module))
+  alias AshHq.Docs.Extensions.RenderMarkdown.PostProcessors.{HeadingAutolinker, Highlighter}
+  alias AshHq.Docs.Extensions.RenderMarkdown.RawHTML
+
+  def run(html, libraries, current_library, current_module, add_ids?, add_table_of_contents?)
+      when is_list(html) do
+    Enum.map(
+      html,
+      &run(&1, libraries, current_library, current_module, add_ids?, add_table_of_contents?)
+    )
   end
 
-  def run(html, libraries, current_library, current_module) do
+  def run(html, libraries, current_library, current_module, add_ids?, _add_table_of_contents?) do
     html
     |> Floki.parse_document!()
-    |> AshHq.Docs.Extensions.RenderMarkdown.PostProcessors.Highlighter.highlight(
-      libraries,
-      current_library,
-      current_module
-    )
-    |> AshHq.Docs.Extensions.RenderMarkdown.RawHTML.raw_html(pretty: true)
+    |> HeadingAutolinker.autolink(add_ids?)
+    |> Highlighter.highlight(libraries, current_library, current_module)
+    |> RawHTML.raw_html(pretty: true)
   end
 end

--- a/lib/ash_hq/docs/extensions/render_markdown/post_processors/heading_autolinker.ex
+++ b/lib/ash_hq/docs/extensions/render_markdown/post_processors/heading_autolinker.ex
@@ -1,0 +1,53 @@
+defmodule AshHq.Docs.Extensions.RenderMarkdown.PostProcessors.HeadingAutolinker do
+  @moduledoc false
+
+  def autolink(ast, false), do: ast
+
+  def autolink(ast, true) do
+    ast
+    |> Floki.traverse_and_update(fn
+      {tag, attrs, [contents]}
+      when tag in ["h1", "h2", "h3", "h4", "h5", "h6"] and is_binary(contents) ->
+        new_attrs = Enum.reject(attrs, fn {key, _} -> key == "id" end)
+
+        id = to_hash(contents)
+        new_attrs = [{"id", id} | new_attrs]
+
+        {"div", [{"class", "flex flex-row items-baseline"}],
+         [
+           {"a", [{"href", "##{id}"}],
+            [
+              {"svg",
+               [
+                 {"xmlns", "http://www.w3.org/2000/svg"},
+                 {"class", "h-6 w-6"},
+                 {"fill", "none"},
+                 {"viewBox", "0 0 24 24"},
+                 {"stroke", "currentColor"},
+                 {"stroke-width", "2"}
+               ],
+               [
+                 {"path",
+                  [
+                    {"stroke-linecap", "round"},
+                    {"stroke-linejoin", "round"},
+                    {"d",
+                     "M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"}
+                  ], []}
+               ]}
+            ]},
+           {tag, new_attrs, [contents]}
+         ]}
+
+      other ->
+        other
+    end)
+  end
+
+  def to_hash(contents) do
+    contents
+    |> String.trim()
+    |> String.replace(~r/[^A-Za-z0-9_]/, "-")
+    |> String.downcase()
+  end
+end

--- a/lib/ash_hq/docs/extensions/render_markdown/post_processors/highlighter.ex
+++ b/lib/ash_hq/docs/extensions/render_markdown/post_processors/highlighter.ex
@@ -1,20 +1,12 @@
-defmodule AshHq.Docs.Extensions.RenderMarkdown.Highlighter do
+defmodule AshHq.Docs.Extensions.RenderMarkdown.PostProcessors.Highlighter do
   @moduledoc false
   # Copied *directly* from nimble_publisher
   # https://github.com/dashbitco/nimble_publisher/blob/v0.1.2/lib/nimble_publisher/highlighter.ex
 
   use AshHqWeb, :verified_routes
 
-  @doc """
-  Highlights all code block in an already generated HTML document.
-  """
-  def highlight(html, libraries, current_library, current_module) when is_list(html) do
-    Enum.map(html, &highlight(&1, libraries, current_library, current_module))
-  end
-
-  def highlight(html, libraries, current_library, current_module) do
-    html
-    |> Floki.parse_document!()
+  def highlight(ast, libraries, current_library, current_module) do
+    ast
     |> Floki.traverse_and_update(fn
       {"a", attrs, contents} ->
         {"a", rewrite_href_attr(attrs, current_library, libraries), contents}
@@ -70,7 +62,6 @@ defmodule AshHq.Docs.Extensions.RenderMarkdown.Highlighter do
       other ->
         other
     end)
-    |> AshHq.Docs.Extensions.RenderMarkdown.RawHTML.raw_html(pretty: true)
   end
 
   defp rewrite_href_attr(attrs, current_library, libraries) do

--- a/lib/ash_hq/docs/extensions/render_markdown/post_processors/table_of_contents_generator.ex
+++ b/lib/ash_hq/docs/extensions/render_markdown/post_processors/table_of_contents_generator.ex
@@ -1,0 +1,140 @@
+defmodule AshHq.Docs.Extensions.RenderMarkdown.PostProcessors.TableOfContentsGenerator do
+  @moduledoc """
+  Auto-generates a table of contents to be rendered as part of the HTML.
+  This links H2s and H3s to their respective parts of the document
+  """
+
+  def generate(ast, false), do: ast
+
+  def generate(ast, true) do
+    case parse_headings(ast) do
+      # No headings
+      [] ->
+        ast
+
+      # Yes headings - we need to build the right AST nodes for them and then insert them into the AST
+      headings ->
+        [main_heading | rest] = ast
+        [main_heading | generate_html(headings)] ++ rest
+    end
+  end
+
+  defp generate_html(headings) do
+    contents =
+      Enum.map(headings, fn [h2 | h3s] ->
+        {_tag, attrs, [text]} = h2
+        {"id", id} = Enum.find(attrs, fn {k, _v} -> k == "id" end)
+
+        {
+          "li",
+          [],
+          [
+            {
+              "a",
+              [
+                {"href", "##{id}"},
+                {"class", "text-primary-light-600 dark:text-primary-dark-400"}
+              ],
+              [String.trim(text)]
+            }
+            | generate_subheadings(h3s)
+          ]
+        }
+      end)
+
+    [
+      {"div",
+       [
+         {"class",
+          "float-right w-[20em] border border-base-light-300 border-base-dark-600 p-4 ml-8 mb-8"}
+       ],
+       [
+         {"p", [{"class", "m-0 font-bold"}],
+          [
+            {"svg",
+             [
+               {"xmlns", "http://www.w3.org/2000/svg"},
+               {"class", "inline-block h-5 w-5"},
+               {"fill", "none"},
+               {"viewBox", "0 0 24 24"},
+               {"stroke", "currentColor"},
+               {"stroke-width", "2"}
+             ],
+             [
+               {"path",
+                [
+                  {"stroke-linecap", "round"},
+                  {"stroke-linejoin", "round"},
+                  {"d",
+                   "M16 4v12l-4-2-4 2V4M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"}
+                ], []}
+             ]},
+            "Table of Contents"
+          ]},
+         {"ol", [], contents}
+       ]}
+    ]
+  end
+
+  defp generate_subheadings([]), do: []
+
+  defp generate_subheadings(h3s) do
+    contents =
+      Enum.map(h3s, fn h3 ->
+        {_tag, attrs, [text]} = h3
+        {"id", id} = Enum.find(attrs, fn {k, _v} -> k == "id" end)
+
+        {
+          "li",
+          [{"class", "my-0.5"}],
+          [
+            {
+              "a",
+              [
+                {"href", "##{id}"},
+                {"class", "text-primary-light-600 dark:text-primary-dark-400"}
+              ],
+              [String.trim(text)]
+            }
+          ]
+        }
+      end)
+
+    [{"ol", [{"class", "list-[lower-alpha] m-0"}], contents}]
+  end
+
+  defp parse_headings(ast) do
+    ast
+    |> Floki.traverse_and_update([], fn
+      {tag, attrs, _contents} = heading, acc when tag in ["h2", "h3"] ->
+        if Enum.find(attrs, fn {k, _v} -> k == "id" end) do
+          {heading, [heading | acc]}
+        else
+          {heading, acc}
+        end
+
+      other, acc ->
+        {other, acc}
+    end)
+    |> elem(1)
+    |> Enum.reverse()
+    |> chunk_by_level()
+  end
+
+  # Group the list of all headings into H2s and their child H3s
+  defp chunk_by_level(list) do
+    list
+    |> Enum.chunk_while(
+      [],
+      fn element, acc ->
+        if elem(element, 0) == "h2" do
+          {:cont, Enum.reverse(acc), [element]}
+        else
+          {:cont, [element | acc]}
+        end
+      end,
+      fn rest -> {:cont, Enum.reverse(rest), []} end
+    )
+    |> tl()
+  end
+end

--- a/lib/ash_hq/docs/extensions/render_markdown/render_markdown.ex
+++ b/lib/ash_hq/docs/extensions/render_markdown/render_markdown.ex
@@ -41,38 +41,6 @@ defmodule AshHq.Docs.Extensions.RenderMarkdown do
     Spark.Dsl.Extension.get_opt(resource, [:render_markdown], :table_of_contents?, [])
   end
 
-  def as_html!(text, libraries, current_module, add_ids? \\ true, add_table_of_contents? \\ false)
-
-  def as_html!(nil, _, _, _, _) do
-    ""
-  end
-
-  def as_html!(%Ash.NotLoaded{}, _libraries, _, _, _) do
-    ""
-  end
-
-  def as_html!(text, libraries, current_module, add_ids?, add_table_of_contents?)
-      when is_list(text) do
-    Enum.map(text, &as_html!(&1, libraries, current_module, add_ids?, add_table_of_contents?))
-  end
-
-  def as_html!(
-        text,
-        libraries,
-        current_library,
-        current_module,
-        add_ids?,
-        _add_table_of_contents?
-      ) do
-    text
-    |> Earmark.as_html!(opts(add_ids?))
-    |> AshHq.Docs.Extensions.RenderMarkdown.Highlighter.highlight(
-      libraries,
-      current_library,
-      current_module
-    )
-  end
-
   def as_html(text, libraries, current_module, add_ids?, add_table_of_contents?)
       when is_list(text) do
     Enum.reduce_while(text, {:ok, [], []}, fn text, {:ok, list, errors} ->

--- a/lib/ash_hq/docs/extensions/render_markdown/render_markdown.ex
+++ b/lib/ash_hq/docs/extensions/render_markdown/render_markdown.ex
@@ -70,13 +70,15 @@ defmodule AshHq.Docs.Extensions.RenderMarkdown do
     |> Earmark.as_html(opts(add_ids?))
     |> case do
       {:ok, html_doc, errors} ->
-        {:ok,
-         AshHq.Docs.Extensions.RenderMarkdown.Highlighter.highlight(
-           html_doc,
-           libraries,
-           current_library,
-           current_module
-         ), errors}
+        processed_html =
+          AshHq.Docs.Extensions.RenderMarkdown.PostProcessor.run(
+            html_doc,
+            libraries,
+            current_library,
+            current_module
+          )
+
+        {:ok, processed_html, errors}
 
       {:error, html_doc, errors} ->
         {:error, html_doc, errors}

--- a/lib/ash_hq/docs/extensions/render_markdown/render_markdown.ex
+++ b/lib/ash_hq/docs/extensions/render_markdown/render_markdown.ex
@@ -65,9 +65,9 @@ defmodule AshHq.Docs.Extensions.RenderMarkdown do
     {:ok, nil, []}
   end
 
-  def as_html(text, libraries, current_library, current_module, add_ids?, _add_table_of_contents?) do
+  def as_html(text, libraries, current_library, current_module, add_ids?, add_table_of_contents?) do
     text
-    |> Earmark.as_html(opts(add_ids?))
+    |> Earmark.as_html()
     |> case do
       {:ok, html_doc, errors} ->
         processed_html =
@@ -75,7 +75,9 @@ defmodule AshHq.Docs.Extensions.RenderMarkdown do
             html_doc,
             libraries,
             current_library,
-            current_module
+            current_module,
+            add_ids?,
+            add_table_of_contents?
           )
 
         {:ok, processed_html, errors}
@@ -84,52 +86,4 @@ defmodule AshHq.Docs.Extensions.RenderMarkdown do
         {:error, html_doc, errors}
     end
   end
-
-  defp opts(true) do
-    [postprocessor: &add_ids/1]
-  end
-
-  defp opts(_) do
-    []
-  end
-
-  defp add_ids({tag, attrs, [contents], meta} = node)
-       when tag in ["h1", "h2", "h3", "h4", "h5", "h6"] and is_binary(contents) do
-    if meta[:handled] do
-      node
-    else
-      new_attrs = Enum.reject(attrs, fn {key, _} -> key == "id" end)
-
-      id = String.downcase(String.replace(contents, ~r/[^A-Za-z0-9_]/, "-"))
-      new_attrs = [{"id", id} | new_attrs]
-
-      {"div", [{"class", "flex flex-row items-baseline"}],
-       [
-         {"a", [{"href", "##{id}"}],
-          [
-            {"svg",
-             [
-               {"xmlns", "http://www.w3.org/2000/svg"},
-               {"class", "h-6 w-6"},
-               {"fill", "none"},
-               {"viewBox", "0 0 24 24"},
-               {"stroke", "currentColor"},
-               {"stroke-width", "2"}
-             ],
-             [
-               {"path",
-                [
-                  {"stroke-linecap", "round"},
-                  {"stroke-linejoin", "round"},
-                  {"d",
-                   "M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"}
-                ], [], %{}}
-             ], %{}}
-          ], %{}},
-         {tag, new_attrs, [contents], %{handled: true}}
-       ], %{}}
-    end
-  end
-
-  defp add_ids(other), do: other
 end

--- a/lib/ash_hq/docs/resources/guide/guide.ex
+++ b/lib/ash_hq/docs/resources/guide/guide.ex
@@ -62,6 +62,7 @@ defmodule AshHq.Docs.Guide do
 
   render_markdown do
     render_attributes text: :text_html
+    table_of_contents? true
   end
 
   graphql do


### PR DESCRIPTION
* Refactors how the `RenderMarkdown` extension generates its HTML, to allow for multiple post-processors to be piped together. Each post-processor takes a Floki AST, can do whatever it wants, and returns a new Floki AST. At the end, the AST is converted to HTML.
* Adds a new post-processor for generating tables of contents for rendered documents
* This post-processor will take any second and third level headings from documents (first-level is the page heading) and build links to each section of the document.
* This functionality can be turned on/off per resource via a new `table_of_contents?` option, and currently is enabled for Guides only.

The table of contents looks like this:

<img width="1457" alt="Screenshot 2023-01-23 at 3 32 40 pm" src="https://user-images.githubusercontent.com/543859/213986668-01d46161-7697-4c38-8f4b-6b8da2f2e82d.png">

<img width="1466" alt="Screenshot 2023-01-23 at 3 32 51 pm" src="https://user-images.githubusercontent.com/543859/213986686-aec50b9c-e0ef-43da-a97e-8f0c126cd3af.png">

It isn't fixed, it floats to the right, so it will scroll with the screen content. Any design advice welcome!

This should help a bit with discoverability of content - its hard to know exactly what each guide covers without reading through the whole thing.

### Possible issues

* By default the TOC post-processor will only include headings with IDs (there are a couple of headings currently in the guides that don't get them, the original Markdown has something like `### **IMPORTANT**`) so it won't break, but some headings might be silently skipped.

* If the `header_ids?` option is turned off, but `table_of_contents?` is turned on, then no TOC will be printed (because no headers will have IDs). Can we make the options dependent somehow? Not necessary?

### Possible improvements

* Writing HTML via AST nodes (most of the TOC post-processor) is kinda ugly. It could probably be refactored to be a little nicer, but it's still gonna be ugly.