### PR TITLE
improvement: Show overflowing text as a `title` tooltip in table of contents

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -188,8 +188,24 @@ Hooks.RightNav = {
       }
       el.setAttribute("aria-current", "true");
     }
-  }
-}
+  },
+};
+
+Hooks.TableOfContentsTextOverflow = {
+  mounted() {
+    this.setTitlesForOverflowingLinks(this.el);
+  },
+  updated() {
+    this.setTitlesForOverflowingLinks(this.el);
+  },
+  setTitlesForOverflowingLinks(selector) {
+    for (elem of selector.querySelectorAll("a")) {
+      if (elem.offsetWidth < elem.scrollWidth) {
+        elem.setAttribute("title", elem.innerHTML.trim());
+      }
+    }
+  },
+};
 
 let csrfToken = document
   .querySelector("meta[name='csrf-token']")

--- a/lib/ash_hq/docs/extensions/render_markdown/post_processors/table_of_contents_generator.ex
+++ b/lib/ash_hq/docs/extensions/render_markdown/post_processors/table_of_contents_generator.ex
@@ -47,6 +47,8 @@ defmodule AshHq.Docs.Extensions.RenderMarkdown.PostProcessors.TableOfContentsGen
     [
       {"div",
        [
+         {"id", "table-of-contents-#{Ash.UUID.generate()}"},
+         {"phx-hook", "TableOfContentsTextOverflow"},
          {"class",
           "md:float-right md:w-[20em] md:border md:border-base-light-300 md:dark:border-base-dark-600 md:p-4 md:ml-8 md:mb-8"}
        ],


### PR DESCRIPTION
Uses a tiny JS hook on generated tables of contents to show overflowing text in `title` attributes.

(screenshot didn't capture my mouse but I'm hovering the link)

<img width="369" alt="Screenshot 2023-01-25 at 10 15 56 am" src="https://user-images.githubusercontent.com/543859/214465572-a4f4744c-9150-465a-8511-bff5590a2e4c.png">

(To get this for current versions of docs, a rebuild will be required)

### Note

We don't seem to have anything within the project for JS formatting, so my editor changed things quite a bit - I didn't include (most of) what it changed but there might be some churn.