### PR TITLE
fix: Links to guides are now correctly converted to AshHQ links on import

### DIFF
--- a/lib/ash_hq/docs/extensions/render_markdown/changes/render_markdown.ex
+++ b/lib/ash_hq/docs/extensions/render_markdown/changes/render_markdown.ex
@@ -40,7 +40,8 @@ defmodule AshHq.Docs.Extensions.RenderMarkdown.Changes.RenderMarkdown do
           end
 
         current_library =
-          case Ash.Changeset.get_attribute(changeset, :library_version_id) do
+          case Ash.Changeset.get_argument(changeset, :library_version) ||
+                 Ash.Changeset.get_attribute(changeset, :library_version_id) do
             nil ->
               nil
 


### PR DESCRIPTION
As discussed on Slack - turns out to be a really simple fix (but this doesn't solve the potential underlying architectural issue).

Something unexpected was happening when setting the `library_version_id` of imported guides, which meant that the `current_library` was nil. If the `current_library` was nil, the Highlighter post-processor was ignoring links instead of rewriting them to be AshHQ links.

Before (the security guide link):
<img width="660" alt="Screenshot 2023-01-25 at 1 51 14 pm" src="https://user-images.githubusercontent.com/543859/214490201-e6466145-5ba6-4629-ad05-eb976a2c0f3b.png">

After: link is correctly rewritten to http://(domain)/docs/guides/ash/latest/security .

Have tested by running a full import locally and all of the other broken links I noticed have also been fixed.