### PR TITLE
improvement: Allow heading margins to collapse in guide content

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -49,6 +49,7 @@ module.exports = {
     "md:border-base-light-300",
     "md:dark:border-base-dark-600",
     "md:ml-8",
+    "md:mb-8",
     "text-ellipsis",
     "overflow-hidden",
   ],

--- a/lib/ash_hq/docs/extensions/render_markdown/post_processors/heading_autolinker.ex
+++ b/lib/ash_hq/docs/extensions/render_markdown/post_processors/heading_autolinker.ex
@@ -10,18 +10,16 @@ defmodule AshHq.Docs.Extensions.RenderMarkdown.PostProcessors.HeadingAutolinker 
       when tag in ["h1", "h2", "h3", "h4", "h5", "h6"] ->
         text_contents = Floki.text(contents)
         new_attrs = Enum.reject(attrs, fn {key, _} -> key == "id" end)
-
         id = to_hash(text_contents)
-        new_attrs = [{"id", id} | new_attrs]
 
-        {"div", [{"class", "flex flex-row items-baseline"}],
+        {tag, [{"id", id}, {"class", "flex flex-row items-center"}],
          [
            {"a", [{"href", "##{id}"}],
             [
               {"svg",
                [
                  {"xmlns", "http://www.w3.org/2000/svg"},
-                 {"class", "h-6 w-6"},
+                 {"class", "h-6 w-6 mr-1"},
                  {"fill", "none"},
                  {"viewBox", "0 0 24 24"},
                  {"stroke", "currentColor"},
@@ -37,7 +35,7 @@ defmodule AshHq.Docs.Extensions.RenderMarkdown.PostProcessors.HeadingAutolinker 
                   ], []}
                ]}
             ]},
-           {tag, new_attrs, [contents]}
+           {"span", new_attrs, [contents]}
          ]}
 
       other ->

--- a/lib/ash_hq/docs/extensions/render_markdown/post_processors/table_of_contents_generator.ex
+++ b/lib/ash_hq/docs/extensions/render_markdown/post_processors/table_of_contents_generator.ex
@@ -22,7 +22,7 @@ defmodule AshHq.Docs.Extensions.RenderMarkdown.PostProcessors.TableOfContentsGen
   defp generate_html(headings) do
     contents =
       Enum.map(headings, fn [h2 | h3s] ->
-        {_tag, attrs, [text]} = h2
+        {_tag, attrs, text} = h2
         text = Floki.text(text)
         {"id", id} = Enum.find(attrs, fn {k, _v} -> k == "id" end)
 
@@ -83,7 +83,7 @@ defmodule AshHq.Docs.Extensions.RenderMarkdown.PostProcessors.TableOfContentsGen
   defp generate_subheadings(h3s) do
     contents =
       Enum.map(h3s, fn h3 ->
-        {_tag, attrs, [text]} = h3
+        {_tag, attrs, text} = h3
 
         text = Floki.text(text)
         {"id", id} = Enum.find(attrs, fn {k, _v} -> k == "id" end)

--- a/lib/ash_hq_web/components/tag.ex
+++ b/lib/ash_hq_web/components/tag.ex
@@ -7,7 +7,7 @@ defmodule AshHqWeb.Components.Tag do
 
   def render(assigns) do
     ~F"""
-    <div class={"rounded-xl p-1 w-min", "bg-red-300 text-black": @color == :red}>
+    <div class={"flex flex-row flex-wrap contents-center px-2 py-1 text-xs font-medium rounded-full", "bg-red-300 text-black": @color == :red}>
       <#slot />
     </div>
     """


### PR DESCRIPTION
Wrapping the headings with margins in parent divs (to allow for autolinking) was preventing margins from collapsing, making spacing between elements way too big

| Before | After |
|--------|-------|
| <img width="549" alt="Screenshot 2023-01-25 at 3 08 27 pm" src="https://user-images.githubusercontent.com/543859/214501570-8ec1d358-b6f5-4588-9c2a-2f7fd5eff9e6.png"> | <img width="562" alt="Screenshot 2023-01-25 at 3 08 35 pm" src="https://user-images.githubusercontent.com/543859/214501580-de5c4d71-d00b-4874-8d0c-2a6c3f594b08.png"> |

ps. I snuck another tiny style fix in there for "required" pills:

| Before | After |
|--------|-------|
| <img width="163" alt="Screenshot 2023-01-25 at 3 17 11 pm" src="https://user-images.githubusercontent.com/543859/214502829-0405a6e8-b3df-4b63-a720-13378253062a.png"> | <img width="177" alt="Screenshot 2023-01-25 at 3 17 15 pm" src="https://user-images.githubusercontent.com/543859/214502839-57ad1ac5-9a47-4082-8134-e508005ead20.png"> |
