### PR TITLE
fix: Close the Search box when a search result is selected

### DIFF
--- a/lib/ash_hq_web/components/search.ex
+++ b/lib/ash_hq_web/components/search.ex
@@ -120,7 +120,7 @@ defmodule AshHqWeb.Components.Search do
       <LivePatch
         class="block w-full text-left"
         to={DocRoutes.doc_link(item, @selected_versions)}
-        opts={id: "result-#{item.id}"}
+        opts={id: "result-#{item.id}", "phx-click": @close}
       >
         <div class={
           "rounded-lg mb-4 py-2 px-2 hover:bg-base-dark-300 dark:hover:bg-base-dark-700",


### PR DESCRIPTION
I noticed yesterday that the Search box doesn't actually close when you click on a result - the page URL changes, the new content is shown, but an empty search box is also shown. Now it closes so you can see what you selected!