### PR TITLE
fix: Remember selected library versions

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -327,3 +327,22 @@ liveSocket.connect();
 // >> liveSocket.enableLatencySim(1000)  // enabled for duration of browser session
 // >> liveSocket.disableLatencySim()
 window.liveSocket = liveSocket;
+
+window.addEventListener("load", function () {
+  window.cookieconsent.initialise({
+    content: {
+      message:
+        "Hi, this website uses essential cookies for remembering your explicitly set preferences, if you opt-in. We do not use google analytics, but we do use plausible.io, an ethical google analytics alternative which does not use any cookies and collects no personal data.",
+      link: null,
+    },
+    type: "opt-in",
+    palette: {
+      popup: {
+        background: "#000",
+      },
+      button: {
+        background: "#f1d600",
+      },
+    },
+  });
+});

--- a/lib/ash_hq_web/plugs/session_plug.ex
+++ b/lib/ash_hq_web/plugs/session_plug.ex
@@ -17,7 +17,7 @@ defmodule AshHqWeb.SessionPlug do
           Plug.Conn.put_session(conn, cookie, nil)
 
         value ->
-          Plug.Conn.put_session(conn, cookie, value |> IO.inspect(label: "cookie"))
+          Plug.Conn.put_session(conn, cookie, value)
       end
     end)
     |> Plug.Conn.assign(:configured_theme, conn.assigns[:configured_theme] || "dark")

--- a/lib/ash_hq_web/templates/layout/root.html.eex
+++ b/lib/ash_hq_web/templates/layout/root.html.eex
@@ -13,29 +13,6 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.0.3/cookieconsent.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.6.2/jquery.min.js"></script>
     <link phx-track-static rel="stylesheet" href="<%= Routes.static_path(@conn, "/assets/app.css") %>"/>
-    <script>
-    const configuredThemeRow = document.cookie
-      .split('; ')
-      .find(row => row.startsWith('theme='))
-
-    if (!configuredThemeRow || configuredThemeRow === "theme=system") {
-      let theme;
-      if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-        theme = "dark";
-      } else {
-        theme = "light";
-      }
-
-      document.documentElement.classList.add(theme);
-      if(theme === "dark") {
-        document.documentElement.classList.remove("light");
-      } else {
-        document.documentElement.classList.remove("dark");
-      };
-
-      document.cookie = 'theme=system;path=/';
-    }
-    </script>
   </head>
   <body class="h-full">
     <%= case live_flash(@flash, :info) do %>

--- a/lib/ash_hq_web/views/app_view_live.ex
+++ b/lib/ash_hq_web/views/app_view_live.ex
@@ -197,8 +197,7 @@ defmodule AshHqWeb.AppViewLive do
 
     {:noreply,
      socket
-     |> assign(:selected_versions, new_selected_versions)
-     |> push_event("selected-versions", new_selected_versions)}
+     |> set_selected_library_versions(new_selected_versions)}
   end
 
   def handle_event("add_version", %{"library" => library}, socket) do
@@ -206,15 +205,13 @@ defmodule AshHqWeb.AppViewLive do
 
     {:noreply,
      socket
-     |> assign(:selected_versions, new_selected_versions)
-     |> push_event("selected-versions", new_selected_versions)}
+     |> set_selected_library_versions(new_selected_versions)}
   end
 
   def handle_event("change-versions", %{"versions" => versions}, socket) do
     {:noreply,
      socket
-     |> assign(:selected_versions, versions)
-     |> push_event("selected-versions", versions)}
+     |> set_selected_library_versions(versions)}
   end
 
   def handle_event("change-types", %{"types" => types}, socket) do
@@ -323,10 +320,15 @@ defmodule AshHqWeb.AppViewLive do
        :selected_types,
        selected_types
      )
-     |> assign(:selected_versions, selected_versions)
      |> assign(configured_theme: configured_theme)
-     |> push_event("selected-versions", selected_versions)
+     |> set_selected_library_versions(selected_versions)
      |> push_event("selected_types", %{types: selected_types})}
+  end
+
+  defp set_selected_library_versions(socket, library_versions) do
+    socket
+    |> assign(:selected_versions, library_versions)
+    |> push_event("selected-versions", library_versions)
   end
 
   def toggle_search(js \\ %JS{}) do


### PR DESCRIPTION
Fixes bug where selected libraries are not being remembered across sessions. The cookie banner was accidentally removed, and without consent being given, we don't set any cookies.

(Also a cleanup because we *were* actually setting a theme cookie in duplicated code, and a bit of refactoring during debugging).