### PR TITLE
improvement: Search modal UI

### DIFF
--- a/lib/ash_hq_web/components/search.ex
+++ b/lib/ash_hq_web/components/search.ex
@@ -46,67 +46,64 @@ defmodule AshHqWeb.Components.Search do
             change_versions={@change_versions}
           />
         </div>
-        <div
-          id="search-body"
-          class="h-full p-6 grid gap-6 grid-rows-[max-content_auto_max-content]"
-          :on-window-keydown="select-next"
-          phx-key="ArrowDown"
-        >
-          <button
-            id="close-search"
-            class="absolute top-6 right-6 h-6 w-6 cursor-pointer z-10 hover:text-base-light-400"
-            :on-click={@close}
-          >
-            <Heroicons.Outline.XIcon class="h-6 w-6" />
-          </button>
-          <div class="flex flex-col w-full sticky">
-            <div class="w-full flex flex-row justify-start top-0">
-              <Heroicons.Outline.SearchIcon class="h-6 w-6 mr-4" />
-              <div class="flex flex-row justify-between w-full mr-10 border-b border-base-light-600">
-                <Form for={:search} change="search" submit="go-to-doc" class="w-full">
-                  <input
-                    id="search-input"
-                    name="search"
-                    value={@search}
-                    phx-debounce={300}
-                    class="text-lg dark:bg-base-dark-850 grow ring-0 outline-none w-full"
-                  />
+        <div id="search-body" class="h-full" :on-window-keydown="select-next" phx-key="ArrowDown">
+          <div class="p-6 h-full grid gap-6 grid-rows-[max-content_auto_max-content]">
+            <button
+              id="close-search"
+              class="absolute top-6 right-6 h-6 w-6 cursor-pointer z-10 hover:text-base-light-400"
+              :on-click={@close}
+            >
+              <Heroicons.Outline.XIcon class="h-6 w-6" />
+            </button>
+            <div class="flex flex-col w-full sticky">
+              <div class="w-full flex flex-row justify-start top-0">
+                <Heroicons.Outline.SearchIcon class="h-6 w-6 mr-4" />
+                <div class="flex flex-row justify-between w-full mr-10 border-b border-base-light-600">
+                  <Form for={:search} change="search" submit="go-to-doc" class="w-full">
+                    <input
+                      id="search-input"
+                      name="search"
+                      value={@search}
+                      phx-debounce={300}
+                      class="text-lg dark:bg-base-dark-850 grow ring-0 outline-none w-full"
+                    />
+                  </Form>
+                </div>
+              </div>
+              <div class="ml-10">
+                <Form for={:types} change={@change_types}>
+                  <div class="flex flex-row space-x-8 flex-wrap mt-2 text-sm text-base-light-500 dark:text-base-dark-300">
+                    <div>Search For:</div>
+                    {#for type <- AshHq.Docs.Extensions.Search.Types.types()}
+                      <div class="flex flex-row items-center">
+                        <Checkbox
+                          class="mr-2"
+                          id={"#{type}-selected"}
+                          value={type in @selected_types}
+                          name={"types[#{type}]"}
+                        />
+                        <label for={"#{type}-selected"}>
+                          {type}
+                        </label>
+                      </div>
+                    {/for}
+                  </div>
                 </Form>
               </div>
             </div>
-            <div class="ml-10">
-              <Form for={:types} change={@change_types}>
-                <div class="flex flex-row space-x-8 flex-wrap mt-2 text-sm text-base-light-500 dark:text-base-dark-300">
-                  <div>Search For:</div>
-                  {#for type <- AshHq.Docs.Extensions.Search.Types.types()}
-                    <div class="flex flex-row items-center">
-                      <Checkbox
-                        class="mr-2"
-                        id={"#{type}-selected"}
-                        value={type in @selected_types}
-                        name={"types[#{type}]"}
-                      />
-                      <label for={"#{type}-selected"}>
-                        {type}
-                      </label>
-                    </div>
-                  {/for}
-                </div>
-              </Form>
+            <div class="grid overflow-auto">
+              {render_items(assigns, @item_list)}
             </div>
-          </div>
-          <div class="grid overflow-auto">
-            {render_items(assigns, @item_list)}
-          </div>
-          <div class="flex flex-row justify-start items-center relative bottom-0">
-            <Heroicons.Outline.CollectionIcon class="w-6 h-6 mr-2" />
-            <AshHqWeb.Components.VersionPills
-              id="search-version-pills"
-              selected_versions={@selected_versions}
-              remove_version={@remove_version}
-              libraries={@libraries}
-              toggle={toggle_libraries()}
-            />
+            <div class="flex flex-row justify-start items-center relative bottom-0">
+              <Heroicons.Outline.CollectionIcon class="w-6 h-6 mr-2" />
+              <AshHqWeb.Components.VersionPills
+                id="search-version-pills"
+                selected_versions={@selected_versions}
+                remove_version={@remove_version}
+                libraries={@libraries}
+                toggle={toggle_libraries()}
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/lib/ash_hq_web/components/search.ex
+++ b/lib/ash_hq_web/components/search.ex
@@ -10,19 +10,19 @@ defmodule AshHqWeb.Components.Search do
   alias Surface.Components.{Form, LivePatch}
   alias Surface.Components.Form.Checkbox
 
-  prop close, :event, required: true
-  prop libraries, :list, required: true
-  prop selected_versions, :map, required: true
-  prop selected_types, :list, required: true
-  prop change_types, :event, required: true
-  prop change_versions, :event, required: true
-  prop remove_version, :event, required: true
-  prop uri, :string, required: true
+  prop(close, :event, required: true)
+  prop(libraries, :list, required: true)
+  prop(selected_versions, :map, required: true)
+  prop(selected_types, :list, required: true)
+  prop(change_types, :event, required: true)
+  prop(change_versions, :event, required: true)
+  prop(remove_version, :event, required: true)
+  prop(uri, :string, required: true)
 
-  data search, :string, default: ""
-  data item_list, :list, default: []
-  data selected_item, :string
-  data selecting_packages, :boolean, default: false
+  data(search, :string, default: "")
+  data(item_list, :list, default: [])
+  data(selected_item, :string)
+  data(selecting_packages, :boolean, default: false)
 
   def render(assigns) do
     ~F"""
@@ -54,8 +54,8 @@ defmodule AshHqWeb.Components.Search do
         >
           <div class="flex flex-col w-full sticky">
             <div class="w-full flex flex-row justify-start top-0">
-              <Heroicons.Outline.SearchIcon class="h-6 w-6 mr-4 ml-4" />
-              <div class="flex flex-row justify-between w-full  pb-3 border-b border-base-light-600">
+              <Heroicons.Outline.SearchIcon class="h-6 w-6 mr-4" />
+              <div class="flex flex-row justify-between w-full border-b border-base-light-600">
                 <Form for={:search} change="search" submit="go-to-doc" class="w-full">
                   <input
                     id="search-input"
@@ -65,14 +65,14 @@ defmodule AshHqWeb.Components.Search do
                     class="text-lg dark:bg-base-dark-850 grow ring-0 outline-none w-full"
                   />
                 </Form>
-                <button id="close-search" class="mr-4 ml-4 h-6 w-6 hover:text-base-light-400" :on-click={@close}>
+                <button id="close-search" class="ml-4 h-6 w-6 hover:text-base-light-400" :on-click={@close}>
                   <Heroicons.Outline.XIcon class="h-6 w-6" />
                 </button>
               </div>
             </div>
-            <div class="ml-2 pl-4">
+            <div class="ml-10">
               <Form for={:types} change={@change_types}>
-                <div class="flex flex-row space-x-8 flex-wrap mt-4">
+                <div class="flex flex-row space-x-8 flex-wrap mt-2 text-sm text-base-light-500 dark:text-base-dark-300">
                   <div>Search For:</div>
                   {#for type <- AshHq.Docs.Extensions.Search.Types.types()}
                     <div class="flex flex-row items-center">
@@ -91,13 +91,11 @@ defmodule AshHqWeb.Components.Search do
               </Form>
             </div>
           </div>
-          <div class="grid">
-            <div class="pl-4 overflow-auto scroll-parent">
-              {render_items(assigns, @item_list)}
-            </div>
+          <div class="grid overflow-auto">
+            {render_items(assigns, @item_list)}
           </div>
           <div class="flex flex-row justify-start items-center relative bottom-0">
-            <div class="flex text-black dark:text-white font-light px-2">
+            <div class="flex text-black dark:text-white font-light">
               Packages:
             </div>
             <AshHqWeb.Components.VersionPills

--- a/lib/ash_hq_web/components/search.ex
+++ b/lib/ash_hq_web/components/search.ex
@@ -48,7 +48,7 @@ defmodule AshHqWeb.Components.Search do
         </div>
         <div
           id="search-body"
-          class="h-full p-6 grid gap-4 grid-rows-[max-content_auto_max-content]"
+          class="h-full p-6 grid gap-6 grid-rows-[max-content_auto_max-content]"
           :on-window-keydown="select-next"
           phx-key="ArrowDown"
         >
@@ -99,9 +99,7 @@ defmodule AshHqWeb.Components.Search do
             {render_items(assigns, @item_list)}
           </div>
           <div class="flex flex-row justify-start items-center relative bottom-0">
-            <div class="flex text-black dark:text-white font-light">
-              Packages:
-            </div>
+            <Heroicons.Outline.CollectionIcon class="w-6 h-6 mr-2" />
             <AshHqWeb.Components.VersionPills
               id="search-version-pills"
               selected_versions={@selected_versions}
@@ -118,54 +116,57 @@ defmodule AshHqWeb.Components.Search do
 
   defp render_items(assigns, items) do
     ~F"""
-    {#for item <- items}
-      <LivePatch
-        class="block w-full text-left"
-        to={DocRoutes.doc_link(item, @selected_versions)}
-        opts={id: "result-#{item.id}", "phx-click": @close}
-      >
-        <div class={
-          "rounded-lg mb-4 py-2 px-2 hover:bg-base-dark-300 dark:hover:bg-base-dark-700",
-          "bg-base-light-400 dark:bg-base-dark-600": @selected_item.id == item.id,
-          "bg-base-light-200 dark:bg-base-dark-850": @selected_item.id != item.id
-        }>
-          <div class="flex justify-start items-center space-x-2 pb-2">
-            <div>
-              {render_item_type(assigns, item)}
-            </div>
-            <div class="flex flex-row flex-wrap">
-              {#for {path_item, index} <- Enum.with_index(item_path(item))}
-                {#if index != 0}
-                  <Heroicons.Solid.ChevronRightIcon class="h-6 w-6" />
-                {/if}
-                <div>
-                  {path_item}
+    <div class="divide-y">
+      {#for item <- items}
+        <LivePatch
+          class="block w-full text-left border-base-light-300 dark:border-base-dark-600"
+          to={DocRoutes.doc_link(item, @selected_versions)}
+          opts={id: "result-#{item.id}", "phx-click": @close}
+        >
+          <div class={
+            "hover:bg-base-light-100 dark:hover:bg-base-dark-750 py-4",
+            "bg-base-light-200 dark:bg-base-dark-700": @selected_item.id == item.id
+          }>
+            <div class="flex justify-start items-center space-x-2 pb-2 pl-2">
+              <div>
+                {render_item_type(assigns, item)}
+              </div>
+              <div class="flex flex-row flex-wrap items-center">
+                {#for {path_item, index} <- Enum.with_index(item_path(item))}
+                  {#if index != 0}
+                    <Heroicons.Solid.ChevronRightIcon class="h-4 w-4 mt-1" />
+                  {/if}
+                  <div>
+                    {path_item}
+                  </div>
+                {/for}
+                <Heroicons.Solid.ChevronRightIcon class="h-4 w-4 mt-1" />
+                <div class="font-bold">
+                  {#if Map.get(item, :name_matches)}
+                    <CalloutText text={item_name(item)} />
+                  {#else}
+                    {item_name(item)}
+                  {/if}
                 </div>
-              {/for}
-              <Heroicons.Solid.ChevronRightIcon class="h-6 w-6" />
-              <div class="font-bold text-lg">
-                {#if Map.get(item, :name_matches)}
-                  <CalloutText text={item_name(item)} />
-                {#else}
-                  {item_name(item)}
-                {/if}
               </div>
             </div>
+            <div class="text-base-light-700 dark:text-base-dark-400 ml-10">
+              {raw(item.search_headline)}
+            </div>
           </div>
-          <div class="text-base-light-700 dark:text-base-dark-400">
-            {raw(item.search_headline)}
-          </div>
-        </div>
-      </LivePatch>
-    {/for}
+        </LivePatch>
+      {/for}
+    </div>
     """
   end
 
   defp render_item_type(assigns, item) do
+    icon_classes = "h-4 w-4 flex-none mt-1 mx-1"
+
     case item_type(item) do
       "Forum" ->
         ~F"""
-        <Heroicons.Outline.UserGroupIcon class="h-4 w-4" />
+        <Heroicons.Outline.UserGroupIcon class={icon_classes} />
         """
 
       "Mix Task" ->
@@ -176,7 +177,7 @@ defmodule AshHqWeb.Components.Search do
           viewBox="0 0 24 24"
           stroke-width="1.5"
           stroke="currentColor"
-          class="w-4 h-4"
+          class={icon_classes}
         >
           <path
             stroke-linecap="round"
@@ -190,23 +191,23 @@ defmodule AshHqWeb.Components.Search do
         case item.type do
           type when type in [:function, :macro] ->
             ~F"""
-            <Heroicons.Outline.CodeIcon class="h-4 w-4" />
+            <Heroicons.Outline.CodeIcon class={icon_classes} />
             """
 
           :callback ->
             ~F"""
-            <Heroicons.Outline.AtSymbolIcon class="h-4 w-4" />
+            <Heroicons.Outline.AtSymbolIcon class={icon_classes} />
             """
 
           :type ->
             ~F"""
-            <Heroicons.Outline.InformationCircleIcon class="h-4 w-4" />
+            <Heroicons.Outline.InformationCircleIcon class={icon_classes} />
             """
         end
 
       "Module" ->
         ~F"""
-        <Heroicons.Outline.CodeIcon class="h-4 w-4" />
+        <Heroicons.Outline.CodeIcon class={icon_classes} />
         """
 
       type when type in ["Dsl", "Option"] ->
@@ -214,12 +215,12 @@ defmodule AshHqWeb.Components.Search do
 
       "Guide" ->
         ~F"""
-        <Heroicons.Outline.BookOpenIcon class="h-4 w-4" />
+        <Heroicons.Outline.BookOpenIcon class={icon_classes} />
         """
 
       _ ->
         ~F"""
-        <Heroicons.Outline.PuzzleIcon class="h-4 w-4" />
+        <Heroicons.Outline.PuzzleIcon class={icon_classes} />
         """
     end
   end

--- a/lib/ash_hq_web/components/search.ex
+++ b/lib/ash_hq_web/components/search.ex
@@ -48,7 +48,7 @@ defmodule AshHqWeb.Components.Search do
         </div>
         <div
           id="search-body"
-          class="h-full px-6 my-6"
+          class="h-full p-6 grid gap-4 grid-rows-[max-content_auto_max-content]"
           :on-window-keydown="select-next"
           phx-key="ArrowDown"
         >
@@ -91,12 +91,12 @@ defmodule AshHqWeb.Components.Search do
               </Form>
             </div>
           </div>
-          <div class="grid h-[80%] mt-3">
+          <div class="grid">
             <div class="pl-4 overflow-auto scroll-parent">
               {render_items(assigns, @item_list)}
             </div>
           </div>
-          <div class="flex flex-row justify-start items-center relative bottom-0 mt-2">
+          <div class="flex flex-row justify-start items-center relative bottom-0">
             <div class="flex text-black dark:text-white font-light px-2">
               Packages:
             </div>

--- a/lib/ash_hq_web/components/search.ex
+++ b/lib/ash_hq_web/components/search.ex
@@ -52,10 +52,17 @@ defmodule AshHqWeb.Components.Search do
           :on-window-keydown="select-next"
           phx-key="ArrowDown"
         >
+          <button
+            id="close-search"
+            class="absolute top-6 right-6 h-6 w-6 cursor-pointer z-10 hover:text-base-light-400"
+            :on-click={@close}
+          >
+            <Heroicons.Outline.XIcon class="h-6 w-6" />
+          </button>
           <div class="flex flex-col w-full sticky">
             <div class="w-full flex flex-row justify-start top-0">
               <Heroicons.Outline.SearchIcon class="h-6 w-6 mr-4" />
-              <div class="flex flex-row justify-between w-full border-b border-base-light-600">
+              <div class="flex flex-row justify-between w-full mr-10 border-b border-base-light-600">
                 <Form for={:search} change="search" submit="go-to-doc" class="w-full">
                   <input
                     id="search-input"
@@ -65,9 +72,6 @@ defmodule AshHqWeb.Components.Search do
                     class="text-lg dark:bg-base-dark-850 grow ring-0 outline-none w-full"
                   />
                 </Form>
-                <button id="close-search" class="ml-4 h-6 w-6 hover:text-base-light-400" :on-click={@close}>
-                  <Heroicons.Outline.XIcon class="h-6 w-6" />
-                </button>
               </div>
             </div>
             <div class="ml-10">


### PR DESCRIPTION
* Fixes a bug where on small screens, the library picker at the bottom of the search modal would overflow the modal
* Tweaks the layout of the modal content, lining things up and removing the big heavy backgrounds

Before:

<img width="1161" alt="Screenshot 2023-01-30 at 11 33 37 am" src="https://user-images.githubusercontent.com/543859/215402606-31cf72cf-8967-4ff9-bf56-86bb32f8f332.png">

After:

<img width="1152" alt="Screenshot 2023-01-30 at 2 12 35 pm" src="https://user-images.githubusercontent.com/543859/215402673-6f5835e2-2161-4d5b-bae9-a82ea9f60128.png">

(I'm not sure why the build is failing, but it's also failing in main for the same reason)