### PR TITLE
improvement: Catalogue UI

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -308,6 +308,12 @@ window.addEventListener("keydown", (event) => {
   }
 });
 
+window.addEventListener("phx:catalogue-call-to-action-dismissed", (event) => {
+  if (cookiesAreAllowed()) {
+    document.cookie = "catalogue_call_to_action_dismissed=true;path=/";
+  }
+});
+
 window.addEventListener("phx:click-on-item", (event) => {
   document.getElementById(event.detail.id).click();
   document.getElementById("close-search").click();

--- a/lib/ash_hq_web/components/catalogue.ex
+++ b/lib/ash_hq_web/components/catalogue.ex
@@ -5,11 +5,12 @@ defmodule AshHqWeb.Components.Catalogue do
   alias Surface.Components.Form
   alias Surface.Components.Form.Select
 
-  prop id, :string, required: true
-  prop libraries, :list, required: true
-  prop selected_versions, :map, required: true
-  prop change_versions, :event, required: true
-  prop toggle, :any
+  prop(id, :string, required: true)
+  prop(libraries, :list, required: true)
+  prop(selected_versions, :map, required: true)
+  prop(change_versions, :event, required: true)
+  prop(toggle, :any)
+  prop(show_catalogue_call_to_action, :boolean, default: false)
 
   def render(assigns) do
     ~F"""
@@ -21,6 +22,13 @@ defmodule AshHqWeb.Components.Catalogue do
             <Heroicons.Solid.XIcon class="h-6 w-6" />
           </button>
         {/if}
+      </div>
+      <div
+        :if={@show_catalogue_call_to_action}
+        class="text-sm my-2 text-base-light-700 dark:text-base-dark-50"
+      >
+        <Heroicons.Outline.ExclamationCircleIcon class="h-4 w-4 inline-block mb-0.5" />
+        You can see this screen at any time by pressing <Heroicons.Solid.PlusIcon class="h-4 w-4 inline-block mb-0.5" /> next to the list of included packages in the sidebar
       </div>
       <Form for={:selected_versions} change={@change_versions} class="lg:grid lg:grid-cols-2">
         {#for library <- Enum.sort_by(@libraries, & &1.order)}

--- a/lib/ash_hq_web/components/catalogue.ex
+++ b/lib/ash_hq_web/components/catalogue.ex
@@ -32,7 +32,7 @@ defmodule AshHqWeb.Components.Catalogue do
                 "text-base-light-500 dark:text-base-dark-300": !value(@selected_versions, library.id)
               ]}>{library.display_name}</div>
               <Select
-                class="rounded-lg text-black"
+                class="rounded-lg text-black dark:bg-base-dark-700 dark:text-white dark:border-0"
                 name={"versions[#{library.id}]"}
                 id={"#{@id}-selected_versions-#{library.id}"}
                 selected={value(@selected_versions, library.id)}

--- a/lib/ash_hq_web/components/catalogue.ex
+++ b/lib/ash_hq_web/components/catalogue.ex
@@ -2,7 +2,6 @@ defmodule AshHqWeb.Components.Catalogue do
   @moduledoc "Renders the catalogue of available packages"
   use Surface.Component
 
-  alias AshHqWeb.Components.CalloutText
   alias Surface.Components.Form
   alias Surface.Components.Form.Select
 
@@ -14,47 +13,51 @@ defmodule AshHqWeb.Components.Catalogue do
 
   def render(assigns) do
     ~F"""
-    <div id={@id} class="w-full h-full overflow-y-auto">
-      <div class="w-full flex justify-between text-center mb-6 text-xl mt-1">
-        <div />
-        <CalloutText text="Ash Libraries" />
-        <div>
-          {#if @toggle}
-            <button id="close-search-versions" phx-click={@toggle}>
-              <Heroicons.Solid.XIcon class="h-4 w-4" />
-            </button>
-          {/if}
-        </div>
+    <div id={@id} class="w-full h-full overflow-y-auto p-6">
+      <div class="w-full flex justify-between">
+        <p class="text-xl font-bold">Select Ash libraries</p>
+        {#if @toggle}
+          <button id="close-search-versions" phx-click={@toggle} class="">
+            <Heroicons.Solid.XIcon class="h-6 w-6" />
+          </button>
+        {/if}
       </div>
-      <Form for={:selected_versions} change={@change_versions} class="flex flex-wrap gap-4 m-4">
+      <Form for={:selected_versions} change={@change_versions} class="lg:grid lg:grid-cols-2">
         {#for library <- Enum.sort_by(@libraries, & &1.order)}
-          <div class="bg-base-light-200 dark:bg-base-dark-700 p-2 rounded-lg flex-grow">
-            <div class="flex justify-between items-center my-1">
-              <div class="font-bold text-xl">
-                <CalloutText text={library.display_name} />
-              </div>
-              <div>
-                <Select
-                  class="rounded-lg text-black"
-                  name={"versions[#{library.id}]"}
-                  id={"#{@id}-selected_versions-#{library.id}"}
-                  selected={value(@selected_versions, library.id)}
-                  options={[{"Hidden", nil}, {"Latest", "latest"}] ++
-                    (library.versions
-                     |> Enum.sort(&(Version.compare(&1.version, &2.version) != :lt))
-                     |> Enum.map(fn version ->
-                       {version.version, version.id}
-                     end))}
-                /></div>
+          <div class="py-6 lg:p-6 lg:even:pl-0 lg:odd:pr-0 flex-grow border-b border-base-light-300 dark:border-base-dark-600">
+            <div class="flex justify-between items-center mb-1">
+              <div class={[
+                "font-bold text-lg",
+                "text-primary-light-600 dark:text-primary-dark-400": value(@selected_versions, library.id),
+                "text-base-light-500 dark:text-base-dark-300": !value(@selected_versions, library.id)
+              ]}>{library.display_name}</div>
+              <Select
+                class="rounded-lg text-black"
+                name={"versions[#{library.id}]"}
+                id={"#{@id}-selected_versions-#{library.id}"}
+                selected={value(@selected_versions, library.id)}
+                options={[{"hidden", nil}] ++ formatted_versions(library.versions)}
+              />
             </div>
-            <div class="max-w-xs">
-              {library.description}
-            </div>
+            {library.description}
           </div>
         {/for}
       </Form>
+
+      <p class="mt-6">... and more coming soon! <img class="h-6 w-6 inline-block" src="/images/ash-logo.png"></p>
     </div>
     """
+  end
+
+  defp formatted_versions(versions) do
+    [{latest, _} | rest] =
+      versions
+      |> Enum.sort(&(Version.compare(&1.version, &2.version) != :lt))
+      |> Enum.map(fn version ->
+        {version.version, version.id}
+      end)
+
+    [{"#{latest} (latest)", "latest"} | rest]
   end
 
   defp value(selected_versions, library_id) do

--- a/lib/ash_hq_web/components/catalogue_modal.ex
+++ b/lib/ash_hq_web/components/catalogue_modal.ex
@@ -18,7 +18,7 @@ defmodule AshHqWeb.Components.CatalogueModal do
     >
       <div
         :on-click-away={AshHqWeb.AppViewLive.toggle_catalogue()}
-        class="dark:text-white absolute rounded-xl left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 w-3/4 h-3/4 bg-white dark:bg-base-dark-850 border-2 dark:border-base-dark-900"
+        class="dark:text-white absolute rounded-xl left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 w-3/4 max-w-[1200px] h-3/4 bg-white dark:bg-base-dark-850 border-2 dark:border-base-dark-900"
       >
         <Catalogue
           id={"#{@id}-contents"}

--- a/lib/ash_hq_web/components/catalogue_modal.ex
+++ b/lib/ash_hq_web/components/catalogue_modal.ex
@@ -4,10 +4,11 @@ defmodule AshHqWeb.Components.CatalogueModal do
 
   alias AshHqWeb.Components.Catalogue
 
-  prop id, :string, required: true
-  prop libraries, :list, required: true
-  prop selected_versions, :map, required: true
-  prop change_versions, :event, required: true
+  prop(id, :string, required: true)
+  prop(libraries, :list, required: true)
+  prop(selected_versions, :map, required: true)
+  prop(change_versions, :event, required: true)
+  prop(show_catalogue_call_to_action, :boolean)
 
   def render(assigns) do
     ~F"""
@@ -25,6 +26,7 @@ defmodule AshHqWeb.Components.CatalogueModal do
           libraries={@libraries}
           selected_versions={@selected_versions}
           change_versions={@change_versions}
+          show_catalogue_call_to_action={@show_catalogue_call_to_action}
         />
       </div>
     </div>

--- a/lib/ash_hq_web/components/search.ex
+++ b/lib/ash_hq_web/components/search.ex
@@ -33,7 +33,7 @@ defmodule AshHqWeb.Components.Search do
     >
       <div
         :on-click-away={AshHqWeb.AppViewLive.toggle_search()}
-        class="dark:text-white absolute rounded-xl left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 w-3/4 h-3/4 bg-white dark:bg-base-dark-850 border-2 dark:border-base-dark-900"
+        class="dark:text-white absolute rounded-xl left-1/2 top-1/2 transform -translate-x-1/2 -translate-y-1/2 w-3/4 h-3/4 max-w-[1200px] bg-white dark:bg-base-dark-850 border-2 dark:border-base-dark-900"
         :on-window-keydown="select-previous"
         phx-key="ArrowUp"
       >

--- a/lib/ash_hq_web/pages/docs.ex
+++ b/lib/ash_hq_web/pages/docs.ex
@@ -20,6 +20,7 @@ defmodule AshHqWeb.Pages.Docs do
   prop(add_version, :event)
   prop(change_version, :event)
   prop(params, :map, required: true)
+  prop(show_catalogue_call_to_action, :boolean)
 
   data(library, :any)
   data(extension, :any)
@@ -100,6 +101,7 @@ defmodule AshHqWeb.Pages.Docs do
             id="module-docs"
             class="w-full nav-anchor text-black dark:text-white relative py-4 md:py-auto"
           >
+            <.catalogue_call_to_action :if={@show_catalogue_call_to_action} />
             {#if @module}
               <h2>{@module.name} <SourceLink module_or_function={@module} library={@library} library_version={@library_version} /></h2>
             {/if}
@@ -309,6 +311,25 @@ defmodule AshHqWeb.Pages.Docs do
     ~F"""
     <div id={docs_container_id(@doc_path)}>
       {raw(@docs)}
+    </div>
+    """
+  end
+
+  def catalogue_call_to_action(assigns) do
+    ~F"""
+    <div
+      class="bg-blue-500 text-white px-4 py-2 mb-8 cursor-pointer flex justify-between items-center"
+      id="catalogue-call-to-action"
+      :on-click={AshHqWeb.AppViewLive.toggle_catalogue()}
+    >
+      <span>View the full range of Ash libraries for authentication, soft deletion, GraphQL and more</span>
+      <button
+        id="close-search"
+        class="h-6 w-6 cursor-pointer"
+        :on-click="dismiss_catalogue_call_to_action"
+      >
+        <Heroicons.Outline.XIcon class="h-6 w-6" />
+      </button>
     </div>
     """
   end

--- a/lib/ash_hq_web/plugs/session_plug.ex
+++ b/lib/ash_hq_web/plugs/session_plug.ex
@@ -5,7 +5,8 @@ defmodule AshHqWeb.SessionPlug do
   @cookies_to_replicate [
     "theme",
     "selected_versions",
-    "selected_types"
+    "selected_types",
+    "catalogue_call_to_action_dismissed"
   ]
 
   def init(_), do: []

--- a/lib/ash_hq_web/views/app_view_live.ex
+++ b/lib/ash_hq_web/views/app_view_live.ex
@@ -115,6 +115,7 @@ defmodule AshHqWeb.AppViewLive do
               change_versions="change-versions"
               selected_versions={@selected_versions}
               libraries={@libraries}
+              show_catalogue_call_to_action={@show_catalogue_call_to_action}
             />
           {#match :user_settings}
             <UserSettings id="user_settings" current_user={@current_user} />
@@ -190,6 +191,13 @@ defmodule AshHqWeb.AppViewLive do
 
   def handle_info({:page_title, title}, socket) do
     {:noreply, assign(socket, :page_title, "Ash Framework - #{title}")}
+  end
+
+  def handle_event("dismiss_catalogue_call_to_action", _, socket) do
+    {:noreply,
+     socket
+     |> assign(:show_catalogue_call_to_action, false)
+     |> push_event("catalogue-call-to-action-dismissed", %{})}
   end
 
   def handle_event("remove_version", %{"library" => library}, socket) do
@@ -311,6 +319,10 @@ defmodule AshHqWeb.AppViewLive do
 
     {:ok,
      socket
+     |> assign(
+       :show_catalogue_call_to_action,
+       session["catalogue_call_to_action_dismissed"] != "true"
+     )
      |> assign(:libraries, libraries)
      |> assign(
        :selected_versions,

--- a/lib/ash_hq_web/views/app_view_live.ex
+++ b/lib/ash_hq_web/views/app_view_live.ex
@@ -80,6 +80,7 @@ defmodule AshHqWeb.AppViewLive do
         libraries={@libraries}
         selected_versions={@selected_versions}
         change_versions="change-versions"
+        show_catalogue_call_to_action={@show_catalogue_call_to_action}
       />
       <button id="search-button" class="hidden" phx-click={AshHqWeb.AppViewLive.toggle_search()} />
       <div


### PR DESCRIPTION
Two goodies today, both related to the catalogue of libraries that can be enabled/disabled - 

* Redesigns the catalogue to be an aligned grid of libraries
* Shows enabled libraries in the primary colour, and condenses the "latest"/latest numbered version options in the dropdown

Originally I thought of hiding the dropdowns, and showing a toggle to enable/disable the library (which would then show the dropdown and have the latest version selected) but I think this is okay.

<img width="1184" alt="Screenshot 2023-01-31 at 4 42 04 pm" src="https://user-images.githubusercontent.com/543859/215710886-88473d52-ce0f-4e32-b85e-b9c521eec699.png">

* As discussed on Discord the other day, adds a reeeally big call to action to point users to the catalogue, to see what libraries are available. (Blue because its the opposite colour of orange and I wanted this baby to stand out.) Clicking it opens the catalogue, with a tip of how to get back here (once they dismiss the CTA).

<img width="1476" alt="Screenshot 2023-01-31 at 4 45 47 pm" src="https://user-images.githubusercontent.com/543859/215711756-b856667e-756f-4136-958c-86512f65dc44.png">
<img width="1132" alt="Screenshot 2023-01-31 at 4 45 56 pm" src="https://user-images.githubusercontent.com/543859/215711771-5d5fac88-3930-4a3e-9192-c59863e7d24f.png">

The tip also goes away once the CTA is dismissed.

(I'm looking into how I can stop VSCode from putting parentheses around all of the props and stuff, it's getting annoying)