### PR TITLE
feature: Add link to the source for the currently-viewed guide on GitHub

### DIFF
--- a/lib/ash_hq_web/helpers.ex
+++ b/lib/ash_hq_web/helpers.ex
@@ -28,4 +28,8 @@ defmodule AshHqWeb.Helpers do
       "https://github.com/#{library.repo_org}/#{library.name}/tree/v#{library_version.version}/#{file}"
     end
   end
+
+  def source_link(%AshHq.Docs.Guide{route: route}, library, library_version) do
+    "https://github.com/#{library.repo_org}/#{library.name}/tree/v#{library_version.version}/documentation/#{route}.md"
+  end
 end

--- a/lib/ash_hq_web/pages/docs.ex
+++ b/lib/ash_hq_web/pages/docs.ex
@@ -112,6 +112,12 @@ defmodule AshHqWeb.Pages.Docs do
                   library_version={@library_version}
                 /></h2>
             {/if}
+            <.github_guide_link
+              :if={@guide}
+              guide={@guide}
+              library={@library}
+              library_version={@library_version}
+            />
             <.docs doc_path={@doc_path} docs={@docs} />
             {#if @extension && !@dsl && !@guide}
               {#case Enum.count_until(Stream.filter(@extension.dsls, &(&1.type == :section)), 2)}
@@ -304,6 +310,26 @@ defmodule AshHqWeb.Pages.Docs do
         {/if}
       </div>
     </div>
+    """
+  end
+
+  def github_guide_link(assigns) do
+    ~F"""
+    <a
+      href={source_link(@guide, @library, @library_version)}
+      target="_blank"
+      class="float-right no-underline mt-1 ml-2 hidden lg:block"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="w-6 h-6 inline-block mr-1 -mt-1 dark:fill-white fill-base-light-600"
+        viewBox="0 0 24 24"
+      >
+        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+      </svg>
+      <span class="underline">View this guide on GitHub</span>
+      <Heroicons.Outline.ExternalLinkIcon class="w-6 h-6 inline-block -mt-1" />
+    </a>
     """
   end
 


### PR DESCRIPTION
Closes #37

It looks like this: 
<img width="1063" alt="Screenshot 2023-02-14 at 2 31 58 pm" src="https://user-images.githubusercontent.com/543859/218657851-8e5dcceb-5291-484a-93de-1a8ed0466189.png">

And works okay when the text wraps:

<img width="975" alt="Screenshot 2023-02-14 at 2 32 44 pm" src="https://user-images.githubusercontent.com/543859/218657858-eca7829b-01c4-43a0-ac54-24f6bf8672b6.png">

The problem with doing this, though, is that because we're linking to released versions of a guide at a given tag, an end user can't simply fork-and-edit to fix any typos/other content.

<img width="397" alt="Screenshot 2023-02-14 at 2 35 36 pm" src="https://user-images.githubusercontent.com/543859/218658187-89dc3b60-3c19-48bd-a6da-a924e814d141.png">

Should we actually link to main instead of the tag, to be forkable/editable, but then what they see on GitHub isn't necessarily what they were just reading on AshHQ?