### PR TITLE
fix: Sanitize option names in search result links

### DIFF
--- a/lib/ash_hq_web/doc_routes.ex
+++ b/lib/ash_hq_web/doc_routes.ex
@@ -101,7 +101,7 @@ defmodule AshHqWeb.DocRoutes do
         "/docs/dsl/#{item.library_name}/#{version(item.version_name, item.library_id, selected_versions)}/#{sanitize_name(item.extension_name)}/#{item.sanitized_path}"
 
       %AshHq.Docs.Option{} = item ->
-        "/docs/dsl/#{item.library_name}/#{version(item.version_name, item.library_id, selected_versions)}/#{sanitize_name(item.extension_name)}/#{item.sanitized_path}##{item.name}"
+        "/docs/dsl/#{item.library_name}/#{version(item.version_name, item.library_id, selected_versions)}/#{sanitize_name(item.extension_name)}/#{item.sanitized_path}##{sanitize_name(item.name)}"
     end
   end
 


### PR DESCRIPTION
Closes #101

Now searching for options with names with special characters (such as `sensitive?` or `generated?`) returns links with correctly sanitized URLs, such as `http://localhost:4000/docs/dsl/ash/latest/resource/attributes/uuid_primary_key#generated-`