### PR TITLE
fix: reduce homepage container margins to make mobile design less squ…

### DIFF
--- a/lib/ash_hq_web/pages/home.ex
+++ b/lib/ash_hq_web/pages/home.ex
@@ -20,7 +20,7 @@ defmodule AshHqWeb.Pages.Home do
   def render(assigns) do
     ~F"""
     <div class="antialiased">
-      <div class="my-2 mx-16 dark:bg-base-dark-850 flex flex-col items-center pt-4 md:pt-12">
+      <div class="my-2 mx-2 dark:bg-base-dark-850 flex flex-col items-center pt-4 md:pt-12">
         <div class="flex flex-col">
           <img class="h-64" src="/images/ash-logo-side.svg">
         </div>


### PR DESCRIPTION
Unfortunately, I wasn't able to setup the project on my machine (Pop!_OS 22.04 LTS).

```
11:29:08.588 [error] Postgrex.Protocol (#PID<0.31256.0>) failed to connect: ** (DBConnection.ConnectionError) tcp connect (localhost:5432): connection refused - :econnrefused
```

But, I think this small class change should make the homepage design look more readable so If this works for you, I would recommend merging it in.

Fixes issue #125 

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
