### PR TITLE
fix(app.js): replace dead live_debugger doc link

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -365,7 +365,7 @@ const features = {
     order: 15,
     links: [
       {
-        link: "https://hexdocs.pm/live_debugger/readme.html",
+        link: "https://hexdocs.pm/live_debugger/",
         name: "Live Debugger",
       },
     ],


### PR DESCRIPTION
This is a dead link: https://hexdocs.pm/live_debugger/readme.html - it now goes to https://hexdocs.pm/live_debugger/welcome.html

However, to prevent it from ever being a problem again, I've removed the html reference to allow hexdocs to redirect you to the right place.


Resolves https://github.com/ash-project/ash_hq/issues/303